### PR TITLE
fix(evals): raise request_timeout_s default from 90 → 240s (ATS-326)

### DIFF
--- a/evals/config/default.yaml
+++ b/evals/config/default.yaml
@@ -1,8 +1,8 @@
 base_url: http://localhost:8000
 replicates: 3
 concurrency: 4
-# 240s: /chat/stream uses Gemini 2.5 Pro with Google Search grounding, which routinely takes
-# 30–60s per call. 90s produced 100% spurious ReadTimeout failures (see baseline_r1_2026_05_23).
+# 240s: /chat/stream (document loading + Gemini 2.5 Flash generation) routinely takes 30–60s.
+# 90s produced 100% spurious ReadTimeout failures (see baseline_r1_2026_05_23).
 # Do not lower this without profiling real p99 latency first.
 request_timeout_s: 240
 persona_model: gemini-2.5-flash

--- a/evals/config/default.yaml
+++ b/evals/config/default.yaml
@@ -1,7 +1,10 @@
 base_url: http://localhost:8000
 replicates: 3
 concurrency: 4
-request_timeout_s: 90
+# 240s: /chat/stream uses Gemini 2.5 Pro with Google Search grounding, which routinely takes
+# 30–60s per call. 90s produced 100% spurious ReadTimeout failures (see baseline_r1_2026_05_23).
+# Do not lower this without profiling real p99 latency first.
+request_timeout_s: 240
 persona_model: gemini-2.5-flash
 judge_model: gemini-2.5-pro
 persona_temperature: 0.8


### PR DESCRIPTION
## What changed

Raised `request_timeout_s` in `evals/config/default.yaml` from 90 to 240 seconds. Added an inline comment explaining the rationale.

## Why

The `/chat/stream` endpoint runs Gemini 2.5 Pro with Google Search grounding, which routinely takes 30–60s per call. At 90s the eval harness hit 100% spurious `ReadTimeout` failures — every single conversation in `baseline_r1_2026_05_23` (16/16) timed out before the bot could respond, producing zero real signal.

The same run at 240s (`baseline_v2_2026_05_23`) yielded real results: 5 pass / 1 partial / 10 fail.

## Reviewer notes

- The comment guards against the value being silently lowered in future. Please don't reduce it without first profiling p99 latency on `/chat/stream`.
- No logic changes — config only.

Closes ATS-326