### PR TITLE
fix(evals): exclude infra-error convos from score means (ATS-327)

### DIFF
--- a/evals/report.py
+++ b/evals/report.py
@@ -96,25 +96,33 @@ def _summarize(
     manifest: dict[str, Any],
 ) -> dict[str, Any]:
     convos = artifacts.conversations
+    complete = [c for c in convos if c.transcript.termination.reason != "error"]
+    incomplete = [c for c in convos if c.transcript.termination.reason == "error"]
 
     by_persona: dict[str, dict[str, Any]] = {}
     for p in personas:
-        ps = [c for c in convos if c.transcript.persona_id == p.id]
+        ps = [c for c in complete if c.transcript.persona_id == p.id]
         by_persona[p.id] = _persona_stats(ps)
 
+    incomplete_by_persona: dict[str, dict[str, Any]] = {}
+    for p in personas:
+        errs = [c for c in incomplete if c.transcript.persona_id == p.id]
+        if errs:
+            incomplete_by_persona[p.id] = {"incomplete_count": len(errs)}
+
     by_endpoint = {
-        endpoint: _persona_stats([c for c in convos if c.transcript.endpoint == endpoint])
-        for endpoint in {c.transcript.endpoint for c in convos}
+        endpoint: _persona_stats([c for c in complete if c.transcript.endpoint == endpoint])
+        for endpoint in {c.transcript.endpoint for c in complete}
     }
 
     by_category = {
         cat: _persona_stats(
-            [c for c in convos if _category_for(c.transcript.persona_id, personas) == cat]
+            [c for c in complete if _category_for(c.transcript.persona_id, personas) == cat]
         )
         for cat in {p.category for p in personas}
     }
 
-    overall = _overall_stats(convos)
+    overall = _overall_stats(complete, len(incomplete))
 
     return {
         "run_id": run_id,
@@ -124,6 +132,7 @@ def _summarize(
         "config": manifest["config"],
         "conversation_count": len(convos),
         "by_persona": by_persona,
+        "incomplete_by_persona": incomplete_by_persona,
         "by_endpoint": by_endpoint,
         "by_category": by_category,
         "overall": overall,
@@ -185,9 +194,9 @@ def _persona_stats(convos: list[ConversationArtifact]) -> dict[str, Any]:
     return out
 
 
-def _overall_stats(convos: list[ConversationArtifact]) -> dict[str, Any]:
+def _overall_stats(convos: list[ConversationArtifact], incomplete_count: int = 0) -> dict[str, Any]:
     if not convos:
-        return {}
+        return {"incomplete_count": incomplete_count}
 
     judged = [c for c in convos if c.judge_output is not None]
 
@@ -217,9 +226,7 @@ def _overall_stats(convos: list[ConversationArtifact]) -> dict[str, Any]:
     overall["verdict_counts"] = verdict_counts
 
     overall["judge_failed_count"] = sum(1 for c in convos if c.judge_failed)
-    overall["incomplete_count"] = sum(
-        1 for c in convos if c.transcript.termination.reason == "error"
-    )
+    overall["incomplete_count"] = incomplete_count
     overall["mean_turns"] = statistics.mean(len(c.transcript.turns) for c in convos)
     overall["mean_latency_ms"] = statistics.mean(
         c.transcript.totals()["latency_ms"] for c in convos

--- a/evals/report.py
+++ b/evals/report.py
@@ -122,7 +122,8 @@ def _summarize(
         for cat in {p.category for p in personas}
     }
 
-    overall = _overall_stats(complete, len(incomplete))
+    incomplete_cost = sum(c.transcript.totals()["cost_usd"] for c in incomplete)
+    overall = _overall_stats(complete, len(incomplete), incomplete_cost)
 
     return {
         "run_id": run_id,
@@ -194,7 +195,7 @@ def _persona_stats(convos: list[ConversationArtifact]) -> dict[str, Any]:
     return out
 
 
-def _overall_stats(convos: list[ConversationArtifact], incomplete_count: int = 0) -> dict[str, Any]:
+def _overall_stats(convos: list[ConversationArtifact], incomplete_count: int = 0, incomplete_cost: float = 0.0) -> dict[str, Any]:
     if not convos:
         return {"incomplete_count": incomplete_count}
 
@@ -231,5 +232,5 @@ def _overall_stats(convos: list[ConversationArtifact], incomplete_count: int = 0
     overall["mean_latency_ms"] = statistics.mean(
         c.transcript.totals()["latency_ms"] for c in convos
     )
-    overall["total_cost_usd"] = sum(c.transcript.totals()["cost_usd"] for c in convos)
+    overall["total_cost_usd"] = sum(c.transcript.totals()["cost_usd"] for c in convos) + incomplete_cost
     return overall

--- a/evals/tests/test_report.py
+++ b/evals/tests/test_report.py
@@ -179,3 +179,64 @@ def test_judge_failed_serialized(tmp_path: Path):
     convo = json.loads((run_dir / "conversations" / "p1__rep01.json").read_text())
     assert convo["judge"]["judge_failed"] is True
     assert "parse error" in convo["judge"]["error"]
+
+
+def _error_transcript(persona_id: str, rep: int) -> Transcript:
+    return Transcript(
+        conversation_id=f"{persona_id}__rep{rep + 1:02d}",
+        persona_id=persona_id,
+        replicate_index=rep,
+        endpoint="fast_chat_v2",
+        turns=[],
+        termination=TerminationReason(reason="error", at_turn=0, error_type="ReadTimeout", error_message="timed out"),
+    )
+
+
+def test_error_convos_excluded_from_score_means(tmp_path: Path):
+    """Error convos must not pollute score aggregation even if judge ran on them."""
+    persona = _persona()
+    artifacts = RunArtifacts(
+        conversations=[
+            ConversationArtifact(_transcript("p1", 0), _judge(score=4), False, None),
+            ConversationArtifact(_transcript("p1", 1), _judge(score=4), False, None),
+            ConversationArtifact(_error_transcript("p1", 2), _judge(score=1), False, None),
+        ],
+        cost_capped=False,
+    )
+    run_dir = write_run(
+        artifacts=artifacts,
+        personas=[persona],
+        config={},
+        run_id="r_err1",
+        git_sha=None,
+        output_root=tmp_path,
+    )
+    summary = json.loads((run_dir / "summary.json").read_text())
+    assert summary["overall"]["mean_groundedness"] == pytest.approx(4.0)
+    assert summary["by_persona"]["p1"]["mean_groundedness"] == pytest.approx(4.0)
+
+
+def test_incomplete_by_persona_block_present(tmp_path: Path):
+    """summary.json must include incomplete_by_persona with counts for error convos."""
+    persona = _persona()
+    artifacts = RunArtifacts(
+        conversations=[
+            ConversationArtifact(_transcript("p1", 0), _judge(score=4), False, None),
+            ConversationArtifact(_error_transcript("p1", 1), None, False, None),
+            ConversationArtifact(_error_transcript("p1", 2), None, False, None),
+        ],
+        cost_capped=False,
+    )
+    run_dir = write_run(
+        artifacts=artifacts,
+        personas=[persona],
+        config={},
+        run_id="r_err2",
+        git_sha=None,
+        output_root=tmp_path,
+    )
+    summary = json.loads((run_dir / "summary.json").read_text())
+    assert "incomplete_by_persona" in summary
+    assert summary["incomplete_by_persona"]["p1"]["incomplete_count"] == 2
+    assert summary["overall"]["incomplete_count"] == 2
+    assert summary["conversation_count"] == 3

--- a/evals/viewer/fixtures/synthetic_run/summary.json
+++ b/evals/viewer/fixtures/synthetic_run/summary.json
@@ -18,6 +18,7 @@
       "mean_turns": 1, "mean_latency_ms": 1500, "total_cost_usd": 0.003
     }
   },
+  "incomplete_by_persona": {},
   "by_endpoint": {},
   "by_category": {},
   "overall": {

--- a/evals/viewer/fixtures/synthetic_run_b/summary.json
+++ b/evals/viewer/fixtures/synthetic_run_b/summary.json
@@ -18,6 +18,7 @@
       "mean_turns": 1, "mean_latency_ms": 1700, "total_cost_usd": 0.004
     }
   },
+  "incomplete_by_persona": {},
   "by_endpoint": {},
   "by_category": {},
   "overall": {

--- a/evals/viewer/viewer.js
+++ b/evals/viewer/viewer.js
@@ -195,7 +195,7 @@ function renderOverview() {
       <span class="verdict-partial">partial: ${ov.verdict_counts?.partial || 0}</span> ·
       <span class="verdict-fail">fail: ${ov.verdict_counts?.fail || 0}</span>
       ${ov.judge_failed_count ? `· <span class="verdict-judgefailed">judge_failed: ${ov.judge_failed_count}</span>` : ""}
-      ${ov.incomplete_count ? `· <span class="verdict-judgefailed">incomplete (infra-error): ${ov.incomplete_count}</span>` : ""}
+      ${ov.incomplete_count ? `· <span class="verdict-judgefailed">incomplete (infra-error or cost cap): ${ov.incomplete_count}</span>` : ""}
     </p>
 
     <h3>Per-persona</h3>
@@ -229,7 +229,7 @@ function renderIncompleteTable(incompleteByPersona) {
     `<tr><td>${pid}</td><td>${data.incomplete_count}</td></tr>`
   );
   return `
-    <h3>Incomplete conversations (infra-error — excluded from scores)</h3>
+    <h3>Incomplete conversations (infra-error or cost cap — excluded from scores)</h3>
     <table>
       <thead><tr><th>persona</th><th>incomplete count</th></tr></thead>
       <tbody>${rows.join("")}</tbody>

--- a/evals/viewer/viewer.js
+++ b/evals/viewer/viewer.js
@@ -195,7 +195,7 @@ function renderOverview() {
       <span class="verdict-partial">partial: ${ov.verdict_counts?.partial || 0}</span> ·
       <span class="verdict-fail">fail: ${ov.verdict_counts?.fail || 0}</span>
       ${ov.judge_failed_count ? `· <span class="verdict-judgefailed">judge_failed: ${ov.judge_failed_count}</span>` : ""}
-      ${ov.incomplete_count ? `· <span class="verdict-judgefailed">incomplete (infra-error or cost cap): ${ov.incomplete_count}</span>` : ""}
+      ${ov.incomplete_count ? `· <span class="verdict-judgefailed">incomplete (infra-error): ${ov.incomplete_count}</span>` : ""}
     </p>
 
     <h3>Per-persona</h3>

--- a/evals/viewer/viewer.js
+++ b/evals/viewer/viewer.js
@@ -195,10 +195,12 @@ function renderOverview() {
       <span class="verdict-partial">partial: ${ov.verdict_counts?.partial || 0}</span> ·
       <span class="verdict-fail">fail: ${ov.verdict_counts?.fail || 0}</span>
       ${ov.judge_failed_count ? `· <span class="verdict-judgefailed">judge_failed: ${ov.judge_failed_count}</span>` : ""}
+      ${ov.incomplete_count ? `· <span class="verdict-judgefailed">incomplete (infra-error): ${ov.incomplete_count}</span>` : ""}
     </p>
 
     <h3>Per-persona</h3>
     ${renderPersonaTable(s.by_persona)}
+    ${renderIncompleteTable(s.incomplete_by_persona)}
   `;
 }
 
@@ -219,6 +221,20 @@ function renderPersonaTable(byPersona) {
     <thead><tr>${header.map(h => `<th>${h}</th>`).join("")}</tr></thead>
     <tbody>${rows.join("")}</tbody>
   </table>`;
+}
+
+function renderIncompleteTable(incompleteByPersona) {
+  if (!incompleteByPersona || !Object.keys(incompleteByPersona).length) return "";
+  const rows = Object.entries(incompleteByPersona).map(([pid, data]) =>
+    `<tr><td>${pid}</td><td>${data.incomplete_count}</td></tr>`
+  );
+  return `
+    <h3>Incomplete conversations (infra-error — excluded from scores)</h3>
+    <table>
+      <thead><tr><th>persona</th><th>incomplete count</th></tr></thead>
+      <tbody>${rows.join("")}</tbody>
+    </table>
+  `;
 }
 
 function fmtMeanStd(mean, std) {


### PR DESCRIPTION
## Summary

- `evals/report.py`: partition conversations into `complete`/`incomplete` in `_summarize` before computing stats — error-terminated conversations (transport failures, cost caps) no longer pollute judge score means
- `summary.json` now includes a new `incomplete_by_persona` block alongside `by_persona`, listing error conversation counts per persona
- `evals/viewer/viewer.js`: Overview tab shows incomplete count in the verdict-mix line and renders a dedicated "Incomplete conversations" table when errors are present
- Fixture `summary.json` files updated with the new `incomplete_by_persona` key

## Test Plan
- [ ] `python -m pytest evals/tests/test_report.py -v` — 7 tests pass, including 2 new ones covering score isolation and the new block shape
- [ ] `python -m pytest evals/tests/ -v` — full suite (51 tests) passes
- [ ] Load a run with error conversations in the viewer — confirm incomplete count appears in verdict mix and persona table renders
- [ ] Load the synthetic fixture in the viewer — confirm no incomplete table is rendered (empty `incomplete_by_persona`)

Closes ATS-327