### PR TITLE
fix(financial_utils): format ratio items by standard_item name (ATS-325)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-fix-ratio-unit-formatting.md
+++ b/docs/superpowers/plans/2026-05-23-fix-ratio-unit-formatting.md
@@ -194,17 +194,15 @@ _CURRENCY_RATIO_ITEMS = frozenset(
     }
 )
 
-# Items stored as a 0–1 fraction that should be displayed as a percentage.
-# If abs(value) <= 1.5 the value is a fraction and is multiplied by 100.
-# If abs(value) > 1.5 the value is already in percent form and is used as-is.
+# Items whose values are sometimes stored as 0–1 fractions and sometimes as already-percent.
+# Values <= 2.0 are treated as fractions (multiplied × 100); values > 2.0 are assumed
+# already in percent form.  Threshold verified against all BQ rows:
+# GK/JMMBGL/JBG payout ratios top out at 0.71; BPOW's percent-stored rows start at 7.2.
+# NOTE: roe, roa, and margin items were intentionally excluded — BQ data shows inconsistent
+# storage conventions across companies with overlapping value ranges, making threshold-based
+# detection unsafe. Those require a separate data-quality investigation.
 _FRACTIONAL_PERCENT_ITEMS = frozenset(
     {
-        "roe",
-        "roa",
-        "gross_profit_margin",
-        "net_profit_margin",
-        "operating_profit_margin",
-        "efficiency_ratio",
         "dividend_payout_ratio",
     }
 )

--- a/docs/superpowers/plans/2026-05-23-fix-ratio-unit-formatting.md
+++ b/docs/superpowers/plans/2026-05-23-fix-ratio-unit-formatting.md
@@ -1,0 +1,309 @@
+# Fix Dividend / Ratio Unit Formatting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the blanket `item_type == "ratio"` → `%` rule with name-based classification so `dividend_per_share` renders as `J$1.90`, fractional ratios like `roe`/`roa`/`dividend_payout_ratio` render as correct percentages, and pure ratios like `current_ratio` render as plain decimals.
+
+**Architecture:** Add three `frozenset` constants near the top of `financial_utils.py` that classify `standard_item` names into currency / fractional-percent / pure-ratio buckets. Replace lines 864–865 (the single-line ratio override) with a name-based dispatch. Use a value threshold (≤1.5) to distinguish fraction-stored vs already-percent items within the fractional bucket, handling the GraceKennedy (0.343) vs BPOW (21.41) `dividend_payout_ratio` split.
+
+**Tech Stack:** Python 3.11, pytest, google-cloud-bigquery mock via monkeypatch.
+
+---
+
+### Task 1: Add failing tests for all three bug cases
+
+**Files:**
+- Modify: `fastapi_app/tests/test_financial_utils.py`
+
+These tests exercise the formatting logic end-to-end through `query_data()` using inline mock rows (no CSV). They must fail on the current code before we touch `financial_utils.py`.
+
+- [ ] **Step 1: Append this test function to `fastapi_app/tests/test_financial_utils.py`**
+
+```python
+# ── Ratio / dividend formatting tests (ATS-325) ──────────────────────────────
+
+
+class _Row:
+    """Minimal BQ row stub for formatting tests."""
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _manager_with_rows(monkeypatch, rows):
+    """Return a FinancialDataManager whose BQ client yields the given rows."""
+
+    class _Result:
+        def result(self):
+            return iter(rows)
+
+    class _Client:
+        def query(self, *a, **kw):
+            return _Result()
+
+    monkeypatch.setattr(
+        "fastapi_app.app.financial_utils.bigquery.Client", lambda *a, **kw: _Client()
+    )
+    from fastapi_app.app.financial_utils import FinancialDataManager
+
+    return FinancialDataManager()
+
+
+def test_dividend_per_share_formats_as_currency(monkeypatch):
+    """Caribbean Cement: dividend_per_share 1.8976 → J$1.90, not 1.90%."""
+    row = _Row(
+        Company="Caribbean Cement Company Limited",
+        Symbol="CCC",
+        Year=2023,
+        standard_item="dividend_per_share",
+        item=1.8976,
+        unit_multiplier=1.0,
+        item_type="ratio",
+        item_name="Dividend Per Share",
+    )
+    manager = _manager_with_rows(monkeypatch, [row])
+    from fastapi_app.app.models import FinancialDataFilters
+
+    results = manager.query_data(FinancialDataFilters())
+    assert len(results) == 1
+    fv = results[0].formatted_value
+    assert fv == "J$1.90", f"Expected 'J$1.90', got '{fv}'"
+
+
+def test_dividend_payout_ratio_fraction_multiplied(monkeypatch):
+    """GraceKennedy: dividend_payout_ratio 0.343 (fraction) → 34.30%, not 0.34%."""
+    row = _Row(
+        Company="GraceKennedy Limited",
+        Symbol="GK",
+        Year=2023,
+        standard_item="dividend_payout_ratio",
+        item=0.343,
+        unit_multiplier=1.0,
+        item_type="ratio",
+        item_name="Dividend Payout Ratio",
+    )
+    manager = _manager_with_rows(monkeypatch, [row])
+    from fastapi_app.app.models import FinancialDataFilters
+
+    results = manager.query_data(FinancialDataFilters())
+    assert len(results) == 1
+    fv = results[0].formatted_value
+    assert fv == "34.30%", f"Expected '34.30%', got '{fv}'"
+
+
+def test_dividend_payout_ratio_already_percent(monkeypatch):
+    """BPOW: dividend_payout_ratio 21.41 (already %) → 21.41%, not 2141%."""
+    row = _Row(
+        Company="Barita Power Limited",
+        Symbol="BPOW",
+        Year=2023,
+        standard_item="dividend_payout_ratio",
+        item=21.41,
+        unit_multiplier=1.0,
+        item_type="ratio",
+        item_name="Dividend Payout Ratio",
+    )
+    manager = _manager_with_rows(monkeypatch, [row])
+    from fastapi_app.app.models import FinancialDataFilters
+
+    results = manager.query_data(FinancialDataFilters())
+    assert len(results) == 1
+    fv = results[0].formatted_value
+    assert fv == "21.41%", f"Expected '21.41%', got '{fv}'"
+
+
+def test_roe_fraction_multiplied(monkeypatch):
+    """ROE 0.53 (fraction) → 53.00%."""
+    row = _Row(
+        Company="Dolla Financial Services Limited",
+        Symbol="DOLLA",
+        Year=2023,
+        standard_item="roe",
+        item=0.53,
+        unit_multiplier=1.0,
+        item_type="ratio",
+        item_name="Return on Equity",
+    )
+    manager = _manager_with_rows(monkeypatch, [row])
+    from fastapi_app.app.models import FinancialDataFilters
+
+    results = manager.query_data(FinancialDataFilters())
+    assert len(results) == 1
+    fv = results[0].formatted_value
+    assert fv == "53.00%", f"Expected '53.00%', got '{fv}'"
+
+
+def test_current_ratio_no_percent_suffix(monkeypatch):
+    """current_ratio 1.11 → '1.11' (plain decimal, no %)."""
+    row = _Row(
+        Company="Some Company",
+        Symbol="SCO",
+        Year=2023,
+        standard_item="current_ratio",
+        item=1.11,
+        unit_multiplier=1.0,
+        item_type="ratio",
+        item_name="Current Ratio",
+    )
+    manager = _manager_with_rows(monkeypatch, [row])
+    from fastapi_app.app.models import FinancialDataFilters
+
+    results = manager.query_data(FinancialDataFilters())
+    assert len(results) == 1
+    fv = results[0].formatted_value
+    assert fv == "1.11", f"Expected '1.11', got '{fv}'"
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```
+cd fastapi_app
+pytest tests/test_financial_utils.py::test_dividend_per_share_formats_as_currency \
+       tests/test_financial_utils.py::test_dividend_payout_ratio_fraction_multiplied \
+       tests/test_financial_utils.py::test_dividend_payout_ratio_already_percent \
+       tests/test_financial_utils.py::test_roe_fraction_multiplied \
+       tests/test_financial_utils.py::test_current_ratio_no_percent_suffix \
+       -v
+```
+
+Expected: all 5 FAIL (wrong formatted_value assertions).
+
+---
+
+### Task 2: Add item-classification constants to `financial_utils.py`
+
+**Files:**
+- Modify: `fastapi_app/app/financial_utils.py` — after line 24 (`USE_DSPY = ...`)
+
+- [ ] **Step 1: Insert constants immediately after the `USE_DSPY` line**
+
+After:
+```python
+USE_DSPY = os.getenv("USE_DSPY", "false").lower() in ("true", "1", "yes")
+```
+
+Insert:
+```python
+
+# Items stored as a monetary value per share (J$/share) — format with J$ prefix
+_CURRENCY_RATIO_ITEMS = frozenset(
+    {
+        "dividend_per_share",
+        "eps",
+    }
+)
+
+# Items stored as a 0–1 fraction that should be displayed as a percentage.
+# If abs(value) <= 1.5 the value is a fraction and is multiplied by 100.
+# If abs(value) > 1.5 the value is already in percent form and is used as-is.
+_FRACTIONAL_PERCENT_ITEMS = frozenset(
+    {
+        "roe",
+        "roa",
+        "gross_profit_margin",
+        "net_profit_margin",
+        "operating_profit_margin",
+        "efficiency_ratio",
+        "dividend_payout_ratio",
+    }
+)
+
+# Items that are dimensionless ratios — display as plain decimal, no % suffix.
+_PURE_RATIO_ITEMS = frozenset(
+    {
+        "current_ratio",
+        "debt_to_equity_ratio",
+    }
+)
+```
+
+---
+
+### Task 3: Replace the single-line ratio override with name-based formatting
+
+**Files:**
+- Modify: `fastapi_app/app/financial_utils.py:859–865`
+
+The existing block is:
+```python
+                item_type = (
+                    get_row_attr(row, "item_type")
+                    if hasattr(row, "item_type") or "item_type" in dir(row)
+                    else ""
+                )
+                if item_type == "ratio" and unit_multiplier == 1.0 and item is not None:
+                    formatted_value = f"{item:.2f}%"
+```
+
+- [ ] **Step 1: Replace those 7 lines with the name-based dispatch**
+
+```python
+                standard_item_key = str(
+                    get_row_attr(row, "standard_item") if item is not None else ""
+                ).lower()
+                item_type = (
+                    get_row_attr(row, "item_type")
+                    if hasattr(row, "item_type") or "item_type" in dir(row)
+                    else ""
+                )
+                if item_type == "ratio" and unit_multiplier == 1.0 and item is not None:
+                    if standard_item_key in _CURRENCY_RATIO_ITEMS:
+                        formatted_value = f"J${item:,.2f}"
+                    elif standard_item_key in _FRACTIONAL_PERCENT_ITEMS:
+                        pct = item * 100 if abs(item) <= 1.5 else item
+                        formatted_value = f"{pct:.2f}%"
+                    elif standard_item_key in _PURE_RATIO_ITEMS:
+                        formatted_value = f"{item:.2f}"
+                    else:
+                        formatted_value = f"{item:.2f}%"
+```
+
+Note: `standard_item_key` is extracted here rather than reusing the `standard_item` from the `FinancialDataRecord` constructor below because the constructor hasn't run yet at this point in the loop.
+
+---
+
+### Task 4: Run all tests and confirm green
+
+- [ ] **Step 1: Run only the new formatting tests**
+
+```
+cd fastapi_app
+pytest tests/test_financial_utils.py::test_dividend_per_share_formats_as_currency \
+       tests/test_financial_utils.py::test_dividend_payout_ratio_fraction_multiplied \
+       tests/test_financial_utils.py::test_dividend_payout_ratio_already_percent \
+       tests/test_financial_utils.py::test_roe_fraction_multiplied \
+       tests/test_financial_utils.py::test_current_ratio_no_percent_suffix \
+       -v
+```
+
+Expected: all 5 PASS.
+
+- [ ] **Step 2: Run the full test suite to check for regressions**
+
+```
+cd fastapi_app
+pytest tests/ -v --tb=short
+```
+
+Expected: all previously passing tests still PASS.
+
+---
+
+### Task 5: Commit
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add fastapi_app/app/financial_utils.py fastapi_app/tests/test_financial_utils.py
+git commit -m "fix(financial_utils): format ratio items by standard_item name not item_type
+
+- dividend_per_share renders as J\$X.XX (currency) not X.XX%
+- roe/roa/margins multiply fraction by 100 before adding %
+- dividend_payout_ratio uses value threshold (<=1.5) to handle
+  both fraction-stored (GraceKennedy 0.343) and percent-stored
+  (BPOW 21.41) variants
+- current_ratio/debt_to_equity_ratio render as plain decimals
+
+Closes ATS-325"
+```

--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -870,13 +870,13 @@ class FinancialDataManager:
                     formatted_value = f"{actual_value:,.0f}"
                 else:
                     formatted_value = f"{actual_value:,.2f}"
-                standard_item_key = str(get_row_attr(row, "standard_item") or "").lower()
                 item_type = (
                     get_row_attr(row, "item_type")
                     if hasattr(row, "item_type") or "item_type" in dir(row)
                     else ""
                 )
                 if item_type == "ratio" and unit_multiplier == 1.0 and item is not None:
+                    standard_item_key = str(get_row_attr(row, "standard_item") or "").lower()
                     if standard_item_key in _CURRENCY_RATIO_ITEMS:
                         formatted_value = f"J${item:,.2f}"
                     elif standard_item_key in _FRACTIONAL_PERCENT_ITEMS:

--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -23,6 +23,20 @@ logger = get_logger(__name__)
 # Feature flag for DSPy usage (default: False for safe rollout)
 USE_DSPY = os.getenv("USE_DSPY", "false").lower() in ("true", "1", "yes")
 
+# Items stored as a monetary value per share (J$/share) — format with J$ prefix, no % suffix.
+# Verified against BQ: all values in J$/share range (0.25–2.0 for dps, -266–86 for eps).
+_CURRENCY_RATIO_ITEMS = frozenset({"dividend_per_share", "eps"})
+
+# Items whose values are sometimes stored as 0–1 fractions and sometimes as already-percent.
+# Convention: values ≤ 2.0 are treated as fractions (multiplied × 100); values > 2.0 are
+# assumed already in percent form.  Threshold verified against all rows in the BQ table:
+# GK/JMMBGL/JBG payout ratios top out at 0.71; BPOW's "dividend_cover" rows start at 7.2.
+_FRACTIONAL_PERCENT_ITEMS = frozenset({"dividend_payout_ratio"})
+
+# Dimensionless ratios — display as plain decimal, no % suffix.
+# BQ data: current_ratio 0.59–14.85; debt_to_equity_ratio -3.14–49.8.
+_PURE_RATIO_ITEMS = frozenset({"current_ratio", "debt_to_equity_ratio"})
+
 
 def get_row_attr(row, attr):
     # Try exact match first
@@ -856,13 +870,22 @@ class FinancialDataManager:
                     formatted_value = f"{actual_value:,.0f}"
                 else:
                     formatted_value = f"{actual_value:,.2f}"
+                standard_item_key = str(get_row_attr(row, "standard_item") or "").lower()
                 item_type = (
                     get_row_attr(row, "item_type")
                     if hasattr(row, "item_type") or "item_type" in dir(row)
                     else ""
                 )
                 if item_type == "ratio" and unit_multiplier == 1.0 and item is not None:
-                    formatted_value = f"{item:.2f}%"
+                    if standard_item_key in _CURRENCY_RATIO_ITEMS:
+                        formatted_value = f"J${item:,.2f}"
+                    elif standard_item_key in _FRACTIONAL_PERCENT_ITEMS:
+                        pct = item * 100 if abs(item) <= 2.0 else item
+                        formatted_value = f"{pct:.2f}%"
+                    elif standard_item_key in _PURE_RATIO_ITEMS:
+                        formatted_value = f"{item:.2f}"
+                    else:
+                        formatted_value = f"{item:.2f}%"
                 record = FinancialDataRecord(
                     company=str(
                         get_row_attr(row, "company")

--- a/fastapi_app/tests/test_financial_utils.py
+++ b/fastapi_app/tests/test_financial_utils.py
@@ -527,16 +527,16 @@ def _manager_with_ratio_rows(monkeypatch, rows):
 
 
 def _ratio_row(**overrides):
-    defaults = dict(
-        Company="Test Company",
-        Symbol="TST",
-        Year=2023,
-        standard_item="dividend_per_share",
-        item=1.0,
-        unit_multiplier=1.0,
-        item_type="ratio",
-        item_name="test_item",
-    )
+    defaults = {
+        "Company": "Test Company",
+        "Symbol": "TST",
+        "Year": 2023,
+        "standard_item": "dividend_per_share",
+        "item": 1.0,
+        "unit_multiplier": 1.0,
+        "item_type": "ratio",
+        "item_name": "test_item",
+    }
     defaults.update(overrides)
     return _RatioRow(**defaults)
 

--- a/fastapi_app/tests/test_financial_utils.py
+++ b/fastapi_app/tests/test_financial_utils.py
@@ -484,3 +484,139 @@ def test_parse_user_query_llm_symbol_only(monkeypatch, mock_bq_client):
     assert filters.standard_items == ["revenue"]
     assert filters.is_follow_up is False
     assert "ELITE" in filters.interpretation
+
+
+# ── ATS-325: ratio / dividend unit formatting tests ────────────────────────────
+
+
+class _RatioRow:
+    """Minimal BQ row stub for formatting tests."""
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def _manager_with_ratio_rows(monkeypatch, rows):
+    """Return a FinancialDataManager whose BQ client yields the given rows."""
+
+    class _Result:
+        def result(self):
+            return iter(rows)
+
+    class _Client:
+        def query(self, *a, **kw):
+            return _Result()
+
+    client = _Client()
+
+    def _fake_init_bq(self):
+        self.bq_client = client
+
+    monkeypatch.setattr(FinancialDataManager, "_initialize_bigquery_client", _fake_init_bq)
+    monkeypatch.setattr(FinancialDataManager, "load_metadata_from_bigquery", lambda self: None)
+    manager = FinancialDataManager()
+    manager.metadata = {
+        "companies": [],
+        "symbols": [],
+        "years": [],
+        "standard_items": [],
+        "associations": {},
+    }
+    return manager
+
+
+def _ratio_row(**overrides):
+    defaults = dict(
+        Company="Test Company",
+        Symbol="TST",
+        Year=2023,
+        standard_item="dividend_per_share",
+        item=1.0,
+        unit_multiplier=1.0,
+        item_type="ratio",
+        item_name="test_item",
+    )
+    defaults.update(overrides)
+    return _RatioRow(**defaults)
+
+
+def test_dividend_per_share_formats_as_currency(monkeypatch):
+    """CCC dividend_per_share 1.8976 → J$1.90, not 1.90% (ATS-325)."""
+    row = _ratio_row(
+        Company="Caribbean Cement Company Limited",
+        Symbol="CCC",
+        standard_item="dividend_per_share",
+        item=1.8976,
+    )
+    manager = _manager_with_ratio_rows(monkeypatch, [row])
+    results = manager.query_data(FinancialDataFilters())
+    assert len(results) == 1
+    assert results[0].formatted_value == "J$1.90", results[0].formatted_value
+
+
+def test_eps_formats_as_currency(monkeypatch):
+    """EPS 2.85 → J$2.85 (ATS-325)."""
+    row = _ratio_row(standard_item="eps", item=2.85)
+    manager = _manager_with_ratio_rows(monkeypatch, [row])
+    results = manager.query_data(FinancialDataFilters())
+    assert results[0].formatted_value == "J$2.85", results[0].formatted_value
+
+
+def test_dividend_payout_ratio_fraction_multiplied(monkeypatch):
+    """GK dividend_payout_ratio 0.343 (fraction) → 34.30%, not 0.34% (ATS-325)."""
+    row = _ratio_row(
+        Company="Gracekennedy Limited",
+        Symbol="GK",
+        standard_item="dividend_payout_ratio",
+        item=0.343,
+    )
+    manager = _manager_with_ratio_rows(monkeypatch, [row])
+    results = manager.query_data(FinancialDataFilters())
+    assert results[0].formatted_value == "34.30%", results[0].formatted_value
+
+
+def test_dividend_payout_ratio_already_percent(monkeypatch):
+    """BPOW dividend_payout_ratio 21.41 (already %) → 21.41%, not 2141% (ATS-325)."""
+    row = _ratio_row(
+        Company="Blue Power Group Limited",
+        Symbol="BPOW",
+        standard_item="dividend_payout_ratio",
+        item=21.41,
+    )
+    manager = _manager_with_ratio_rows(monkeypatch, [row])
+    results = manager.query_data(FinancialDataFilters())
+    assert results[0].formatted_value == "21.41%", results[0].formatted_value
+
+
+def test_current_ratio_no_percent_suffix(monkeypatch):
+    """current_ratio 1.11 → '1.11' (plain decimal, no %) (ATS-325)."""
+    row = _ratio_row(standard_item="current_ratio", item=1.11)
+    manager = _manager_with_ratio_rows(monkeypatch, [row])
+    results = manager.query_data(FinancialDataFilters())
+    assert results[0].formatted_value == "1.11", results[0].formatted_value
+
+
+def test_debt_to_equity_ratio_no_percent_suffix(monkeypatch):
+    """debt_to_equity_ratio 1.06 → '1.06' (plain decimal, no %) (ATS-325)."""
+    row = _ratio_row(standard_item="debt_to_equity_ratio", item=1.06)
+    manager = _manager_with_ratio_rows(monkeypatch, [row])
+    results = manager.query_data(FinancialDataFilters())
+    assert results[0].formatted_value == "1.06", results[0].formatted_value
+
+
+def test_unknown_ratio_keeps_percent_suffix(monkeypatch):
+    """Unknown ratio items still get % appended (default behaviour preserved)."""
+    row = _ratio_row(standard_item="some_other_ratio", item=0.75)
+    manager = _manager_with_ratio_rows(monkeypatch, [row])
+    results = manager.query_data(FinancialDataFilters())
+    assert results[0].formatted_value == "0.75%", results[0].formatted_value
+
+
+def test_non_ratio_item_type_unaffected(monkeypatch):
+    """Items with item_type != 'ratio' are not touched by the ratio branch."""
+    row = _ratio_row(standard_item="revenue", item=1000.0, unit_multiplier=1000000.0, item_type="currency")
+    manager = _manager_with_ratio_rows(monkeypatch, [row])
+    results = manager.query_data(FinancialDataFilters())
+    # 1000 * 1_000_000 = 1_000_000_000 → "1.00B" (hits the >= 1e9 branch)
+    assert "B" in results[0].formatted_value, results[0].formatted_value

--- a/fastapi_app/tests/test_financial_utils.py
+++ b/fastapi_app/tests/test_financial_utils.py
@@ -615,7 +615,9 @@ def test_unknown_ratio_keeps_percent_suffix(monkeypatch):
 
 def test_non_ratio_item_type_unaffected(monkeypatch):
     """Items with item_type != 'ratio' are not touched by the ratio branch."""
-    row = _ratio_row(standard_item="revenue", item=1000.0, unit_multiplier=1000000.0, item_type="currency")
+    row = _ratio_row(
+        standard_item="revenue", item=1000.0, unit_multiplier=1000000.0, item_type="currency"
+    )
     manager = _manager_with_ratio_rows(monkeypatch, [row])
     results = manager.query_data(FinancialDataFilters())
     # 1000 * 1_000_000 = 1_000_000_000 → "1.00B" (hits the >= 1e9 branch)


### PR DESCRIPTION
## Summary

Fixes the blanket `item_type == 'ratio'` → `X.XX%` formatting rule in `financial_utils.py` that was producing wrong output for three categories of items.

**Root cause:** Line 864 applied a `%` suffix to every row with `item_type == 'ratio'` regardless of what the value actually represents, causing:
- `dividend_per_share = 1.8976` (J$/share) → rendered as `"1.90%"` instead of `"J$1.90"`
- `dividend_payout_ratio = 0.343` (fraction = 34.3%) → rendered as `"0.34%"` (off by 100×)
- `current_ratio = 1.11` (dimensionless) → rendered as `"1.11%"` (wrong unit)

## Changes

**`fastapi_app/app/financial_utils.py`**

Adds three `frozenset` constants that classify `standard_item` names, then replaces the single-line override with a name-based dispatch:

| Bucket | Items | Format |
|---|---|---|
| `_CURRENCY_RATIO_ITEMS` | `dividend_per_share`, `eps` | `J$X.XX` |
| `_FRACTIONAL_PERCENT_ITEMS` | `dividend_payout_ratio` | `×100` if value ≤ 2.0, else as-is `%` |
| `_PURE_RATIO_ITEMS` | `current_ratio`, `debt_to_equity_ratio` | plain decimal |
| (default) | everything else | unchanged `X.XX%` |

The `dividend_payout_ratio` threshold of 2.0 was verified against every row in the BQ table (`jse_raw_financial_data_dev_elroy.multiyear_financial_data`): fraction-stored rows (GK, JMMBGL, JBG, KPREIT, PJAM, WIG) all top out at 0.71; BPOW's percent-stored "dividend_cover" rows start at 7.2 — clean gap.

**`fastapi_app/tests/test_financial_utils.py`**

Adds 8 new tests covering all cases above, including:
- CCC `dividend_per_share` 1.8976 → `J$1.90`
- GK `dividend_payout_ratio` 0.343 → `34.30%`
- BPOW `dividend_payout_ratio` 21.41 → `21.41%` (already-percent, no multiply)
- `current_ratio` → plain decimal
- `debt_to_equity_ratio` → plain decimal
- Unknown ratio items → default `%` behaviour preserved
- Non-ratio `item_type` → untouched

## What's not fixed here

`roe`, `roa`, and margin items have inconsistent storage conventions across companies in the BQ table (e.g. FESCO ROE stored as 41–55 percent-form; Carreras ROE stored as 0.93–2.55 fraction) with overlapping value ranges that make threshold-based detection unsafe. Those need a separate data-quality investigation.

## Test plan

- [x] 8 new formatting tests all pass
- [x] Pre-existing test failures are unchanged (10 pre-existing failures due to missing service account credentials in test env — not introduced by this PR)

Closes [ATS-325](https://linear.app/galbraith-family/issue/ATS-325/r1-fix-dividend-ratio-unit-formatting-in-financial-utils)

🤖 Generated with [Claude Code](https://claude.com/claude-code)