### PR TITLE
feat(evals): lower default concurrency to 2; add per-conversation logging

### DIFF
--- a/evals/cli.py
+++ b/evals/cli.py
@@ -122,7 +122,8 @@ async def _amain(ns: argparse.Namespace) -> int:
     started_at = datetime.now(timezone.utc).isoformat()
     print(
         f"Running {len(personas)} persona(s) × {config.replicates} replicate(s) "
-        f"= {len(personas) * config.replicates} conversation(s)..."
+        f"= {len(personas) * config.replicates} conversation(s) "
+        f"(concurrency={config.concurrency})..."
     )
     artifacts = await run_simulation(
         personas=personas,

--- a/evals/config/default.yaml
+++ b/evals/config/default.yaml
@@ -1,6 +1,6 @@
 base_url: http://localhost:8000
 replicates: 3
-concurrency: 4
+concurrency: 2
 # 240s: /chat/stream (document loading + Gemini 2.5 Flash generation) routinely takes 30–60s.
 # 90s produced 100% spurious ReadTimeout failures (see baseline_r1_2026_05_23).
 # Do not lower this without profiling real p99 latency first.

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -185,6 +185,7 @@ async def run_simulation(
         async with judge_semaphore:
             try:
                 output = await judge.evaluate(persona=persona, transcript=transcript)
+                print(f"  {persona.id} rep{rep+1}: {output.verdict} (turns={len(transcript.turns)}, ${convo_cost:.3f})")
                 return ConversationArtifact(transcript, output, False, None)
             except Exception as exc:
                 return ConversationArtifact(transcript, None, True, f"{type(exc).__name__}: {exc}")

--- a/evals/tests/test_config.py
+++ b/evals/tests/test_config.py
@@ -11,7 +11,7 @@ def test_load_default():
     config = load_config()
     assert config.base_url == "http://localhost:8000"
     assert config.replicates == 3
-    assert config.concurrency == 4
+    assert config.concurrency == 2
     assert config.persona_model == "gemini-2.5-flash"
     assert config.judge_model == "gemini-2.5-pro"
     assert config.max_cost_usd_per_run == 5.00


### PR DESCRIPTION
## Summary
- Lowers `evals/config/default.yaml` concurrency from 4 → 2 to avoid queue-induced timeouts on the single-worker uvicorn server
- Adds a per-conversation verdict line after each `judge.evaluate` call: `{persona.id} rep{N}: {verdict} (turns=X, $Y.YYY)`
- Adds concurrency count to the run start header for context

Closes ATS-329.

## Test plan
- [ ] `pytest evals/tests/test_config.py evals/tests/test_runner.py` passes (11 tests)
- [ ] Run an eval and confirm per-conversation lines appear in stdout during the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)