### PR TITLE
feat(agent_v2): honor enable_web_search flag (ATS-331)

### DIFF
--- a/fastapi_app/app/agent_v2.py
+++ b/fastapi_app/app/agent_v2.py
@@ -50,6 +50,9 @@ SYSTEM_PROMPT = """You are JSE Financial Analyst, an expert AI assistant for the
 
 You have web search access for current market data."""
 
+SYSTEM_PROMPT_NO_SEARCH = SYSTEM_PROMPT.replace(
+    "\nYou have web search access for current market data.", ""
+)
 
 # ==============================================================================
 # AGENT V2 - Simple Google Search Grounding
@@ -248,14 +251,13 @@ class AgentV2:
         enable_web_search: bool = True,
     ) -> Dict[str, Any]:
         """
-        Run the agent with Google Search grounding.
-
-        This makes a single generate_content call with the GoogleSearch tool
-        for web grounding, following the simpler approach from the example script.
+        Run the agent, optionally with Google Search grounding.
 
         Args:
             query: User's question
             conversation_history: Previous conversation messages
+            enable_web_search: When False, omits the GoogleSearch tool and removes
+                the web-search instruction from the system prompt.
 
         Returns:
             Dictionary compatible with AgentChatResponse
@@ -268,15 +270,15 @@ class AgentV2:
             # Build conversation contents
             contents = self._build_contents(conversation_history, query)
 
-            # Conditionally include Google Search grounding tool
-            tools = [types.Tool(google_search=types.GoogleSearch())] if enable_web_search else []
+            tools = [types.Tool(google_search=types.GoogleSearch())] if enable_web_search else None
+            system_prompt = SYSTEM_PROMPT if enable_web_search else SYSTEM_PROMPT_NO_SEARCH
 
-            # Single generate_content call with grounding
+            # Single generate_content call with optional grounding
             response = self.client.models.generate_content(
                 model=self.model_name,
                 contents=contents,
                 config=types.GenerateContentConfig(
-                    system_instruction=SYSTEM_PROMPT,
+                    system_instruction=system_prompt,
                     temperature=0.7,
                     top_p=0.95,
                     max_output_tokens=8192,

--- a/fastapi_app/app/agent_v2.py
+++ b/fastapi_app/app/agent_v2.py
@@ -245,6 +245,7 @@ class AgentV2:
         self,
         query: str,
         conversation_history: Optional[List[Dict[str, str]]] = None,
+        enable_web_search: bool = True,
     ) -> Dict[str, Any]:
         """
         Run the agent with Google Search grounding.
@@ -267,8 +268,8 @@ class AgentV2:
             # Build conversation contents
             contents = self._build_contents(conversation_history, query)
 
-            # Google Search tool for grounding
-            google_search_tool = types.Tool(google_search=types.GoogleSearch())
+            # Conditionally include Google Search grounding tool
+            tools = [types.Tool(google_search=types.GoogleSearch())] if enable_web_search else []
 
             # Single generate_content call with grounding
             response = self.client.models.generate_content(
@@ -279,7 +280,7 @@ class AgentV2:
                     temperature=0.7,
                     top_p=0.95,
                     max_output_tokens=8192,
-                    tools=[google_search_tool],
+                    tools=tools,
                 ),
             )
 

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -987,6 +987,7 @@ async def chat_stream(
         result = await agent.run(
             query=request.query,
             conversation_history=request.conversation_history,
+            enable_web_search=request.enable_web_search,
         )
 
         # Build response (compatible with AgentChatResponse)
@@ -1071,6 +1072,7 @@ async def chat_stream_v2(
         result = await agent.run(
             query=request.query,
             conversation_history=request.conversation_history,
+            enable_web_search=request.enable_web_search,
         )
 
         # Build response (compatible with AgentChatResponse)


### PR DESCRIPTION
## Summary

- `AgentV2.run()` now accepts an `enable_web_search` parameter (default `True`)
- When `False`, the `GoogleSearch` tool is omitted from the `GenerateContentConfig` — the model gets no grounding tool
- Both `/chat/agent` call sites in `main.py` now forward `request.enable_web_search` into `agent.run()`

## Why

Personas like `negative_prompt_injection` set `enable_web_search: false` to test pure-prompt resistance. Previously the flag was ignored and the bot searched the web anyway, making those evals measure the wrong thing.

## Reviewer notes

- `enable_financial_data` is intentionally left as a no-op for now (no financial tool in AgentV2 yet — tracked in R10)
- Pre-existing test failures (38) are all google-auth errors unrelated to this change; baseline confirmed unchanged

Closes ATS-331