### PR TITLE
refactor(ATS-330): archive AgentOrchestrator instead of deleting it

### DIFF
--- a/fastapi_app/app/_archive/README.md
+++ b/fastapi_app/app/_archive/README.md
@@ -15,6 +15,10 @@ patterns, financial DB query logic) that may be revived in a future ticket (see 
 ## Restoring
 
 To wire `AgentOrchestrator` back up (ticket R10):
-1. Move `agent_orchestrator.py` back to `app/agent.py`
+1. Move `agent_orchestrator.py` back to `app/agent.py` and remove the `ARCHIVED` header from the module docstring
 2. Re-add `from app.agent import AgentOrchestrator` in `main.py`
-3. Instantiate it in the lifespan and route `/chat/stream` through it
+3. In the `lifespan` context manager in `main.py`, instantiate the orchestrator after `financial_manager` is ready and store it on app state:
+   ```python
+   app.state.agent_orchestrator = AgentOrchestrator(financial_manager=app.state.financial_manager)
+   ```
+4. In the `/chat/stream` endpoint, swap out `AgentV2` for `app.state.agent_orchestrator` — note that `AgentOrchestrator.run()` returns a full dict (not a streaming generator), so the endpoint response shape will need to be reconciled with the current streaming contract

--- a/fastapi_app/app/_archive/README.md
+++ b/fastapi_app/app/_archive/README.md
@@ -1,0 +1,20 @@
+# _archive
+
+This directory holds code that is **not active** but is preserved for reference.
+
+Files here are intentionally excluded from the running application. They are kept
+because they document non-obvious capabilities (tool declarations, 3-phase pipeline
+patterns, financial DB query logic) that may be revived in a future ticket (see R10).
+
+## Contents
+
+| File | Original path | What it is |
+|---|---|---|
+| `agent_orchestrator.py` | `app/agent.py` | `AgentOrchestrator` — a 3-phase agent (clarification → routing → synthesis) with both Google Search grounding *and* JSE financial-DB tool calling via Gemini function calling. Was imported in `main.py` but never instantiated; all live endpoints use the simpler `AgentV2` instead. |
+
+## Restoring
+
+To wire `AgentOrchestrator` back up (ticket R10):
+1. Move `agent_orchestrator.py` back to `app/agent.py`
+2. Re-add `from app.agent import AgentOrchestrator` in `main.py`
+3. Instantiate it in the lifespan and route `/chat/stream` through it

--- a/fastapi_app/app/_archive/agent_orchestrator.py
+++ b/fastapi_app/app/_archive/agent_orchestrator.py
@@ -1,9 +1,12 @@
 """
-Simplified Agent module for orchestrating Gemini with multiple tools.
+ARCHIVED — not imported by the running application (see _archive/README.md).
 
-This module provides the AgentOrchestrator class that combines:
-- Google Search (native Gemini tool) for web grounding
-- SQL Query Tool (custom) for financial database queries
+Original path: fastapi_app/app/agent.py  |  Archived: ATS-330
+
+AgentOrchestrator — 3-phase agent combining Google Search grounding with JSE
+financial-DB tool calling via Gemini function calling. Superseded by AgentV2
+(web grounding only) for live endpoints. Preserved for R10 (restore financial
+tool calling on /chat/stream).
 
 Architecture: 3-phase pipeline
 1. Smart Optimization - Single LLM call for clarification, routing, pronoun resolution

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -32,7 +32,6 @@ from app.metadata_loader import load_metadata_from_s3
 from app.document_selector import auto_load_relevant_documents
 from app.streaming_chat import process_streaming_chat
 from app.financial_utils import FinancialDataManager
-from app.agent import AgentOrchestrator
 from app.agent_v2 import AgentV2
 from app.job_store import JobStore, JobProgressSink
 from app.redis_job_store import RedisJobStore


### PR DESCRIPTION
## Summary

- Moves `fastapi_app/app/agent.py` → `fastapi_app/app/_archive/agent_orchestrator.py` so the 3-phase agent is preserved without polluting active code
- Removes the dead `from app.agent import AgentOrchestrator` import in `main.py` (it was never instantiated)
- Adds `fastapi_app/app/_archive/README.md` documenting what lives there, why it was archived, and exact steps to restore it for R10

## Why

`AgentOrchestrator` is a 1087-line 3-phase agent (clarification → routing → synthesis) with both Google Search grounding and JSE financial-DB tool calling via Gemini function calling. It was imported in `main.py` but never wired up — all live endpoints use the simpler `AgentV2` instead. This created a false signal of capability for anyone reading the code (including coding agents).

Rather than delete it outright (per the team's preference), the code is moved to `_archive/` so it remains discoverable and recoverable for ticket R10 (restore financial tool calling on `/chat/stream`), while the `_` prefix makes clear to both humans and automated agents that the directory is not active.

## Reviewer notes

- No runtime behaviour changes — `AgentV2` continues to serve all endpoints unchanged
- The archive directory is intentionally not a Python package (no `__init__.py`), so nothing in it is importable by accident
- Restoring instructions are in `_archive/README.md`

Closes ATS-330