### PR TITLE
fix(financial_utils): restrict follow-up suggestions to actual dataset dimensions (ATS-333)

### DIFF
--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -716,16 +716,19 @@ class FinancialDataManager:
         # --- Filter standard_items: only keep valid ones (case-insensitive) ---
         if "standard_items" in result and result["standard_items"]:
             original_items = list(result["standard_items"])
+            dropped: list = []
             valid_items = []
-            for item in original_items:
-                # Accept if exact match (case-insensitive)
-                for s in all_standard_items:
-                    if item.lower() == s.lower():
-                        valid_items.append(s)  # Keep the original case from metadata
-                        break
+            if original_items:
+                standard_items_map = {s.lower(): s for s in all_standard_items}
+                seen_dropped: set = set()
+                for item in original_items:
+                    lowered = item.lower()
+                    if lowered in standard_items_map:
+                        valid_items.append(standard_items_map[lowered])
+                    elif lowered not in seen_dropped:
+                        dropped.append(item)
+                        seen_dropped.add(lowered)
             result["standard_items"] = valid_items
-            valid_lower = {v.lower() for v in valid_items}
-            dropped = [item for item in original_items if item.lower() not in valid_lower]
             if dropped:
                 result.setdefault("unrecognized_items", []).extend(dropped)
                 logger.warning(f"Metrics not in dataset: {dropped}")
@@ -1165,7 +1168,7 @@ class FinancialDataManager:
 
         if not records:
             if unrecognized_items:
-                items_str = ", ".join(f"'{i}'" for i in unrecognized_items)
+                items_str = ", ".join(f"'{i}'" for i in sorted(set(unrecognized_items)))
                 msg = f"The metric(s) {items_str} are not available in our dataset."
                 if self.metadata and self.metadata.get("standard_items"):
                     sample = ", ".join(self.metadata["standard_items"][:20])
@@ -1199,21 +1202,14 @@ class FinancialDataManager:
         if self.metadata:
             available_years = ", ".join(self.metadata.get("years", []))
             available_metrics = ", ".join(self.metadata.get("standard_items", []))
-            followup_constraint = (
-                "IMPORTANT: Only suggest follow-up questions about data the database actually contains.\n"
-                f"            Available years: {available_years}\n"
-                f"            Available metrics: {available_metrics}\n"
-                "            Valid follow-ups: a different year from the list above, a different metric "
-                "from the list above, or comparing a different company/symbol.\n"
-                "            Do NOT suggest share prices, dividends per share, analyst ratings, or any "
-                "metric not in the available metrics list."
-            )
+            followup_constraint = f"""IMPORTANT: Only suggest follow-up questions about data the database actually contains.
+Available years: {available_years}
+Available metrics: {available_metrics}
+Valid follow-ups: a different year from the list above, a different metric from the list above, or comparing a different company/symbol.
+Do NOT provide any analysis, data, or commentary regarding share prices, dividends per share, analyst ratings, or any metric not in the available metrics list."""
         else:
-            followup_constraint = (
-                "IMPORTANT: Only suggest follow-up questions about data you have seen returned above.\n"
-                "            Do NOT suggest share prices, dividends per share, or any metric "
-                "not already shown in the results."
-            )
+            followup_constraint = """IMPORTANT: Only suggest follow-up questions about data you have seen returned above.
+Do NOT provide any analysis, data, or commentary regarding share prices, dividends per share, or any metric not already shown in the results."""
         prompt = f"""
             Create a concise, informative response to the user's financial data query.
             {'This is a follow-up question in an ongoing conversation.' if is_follow_up else ''}

--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -715,16 +715,20 @@ class FinancialDataManager:
 
         # --- Filter standard_items: only keep valid ones (case-insensitive) ---
         if "standard_items" in result and result["standard_items"]:
+            original_items = list(result["standard_items"])
             valid_items = []
-            for item in result["standard_items"]:
+            for item in original_items:
                 # Accept if exact match (case-insensitive)
                 for s in all_standard_items:
                     if item.lower() == s.lower():
                         valid_items.append(s)  # Keep the original case from metadata
                         break
             result["standard_items"] = valid_items
-            if len(valid_items) != len(result["standard_items"]):
-                logger.warning("Some standard_items were not found in metadata")
+            valid_lower = {v.lower() for v in valid_items}
+            dropped = [item for item in original_items if item.lower() not in valid_lower]
+            if dropped:
+                result.setdefault("unrecognized_items", []).extend(dropped)
+                logger.warning(f"Metrics not in dataset: {dropped}")
 
         return result
 
@@ -1136,6 +1140,7 @@ class FinancialDataManager:
         interpretation: str,
         is_follow_up: bool = False,
         conversation_history: Optional[List[Dict[str, str]]] = None,
+        unrecognized_items: Optional[List[str]] = None,
     ) -> str:
         """Format the query results into a readable response with conversation awareness"""
 
@@ -1159,6 +1164,15 @@ class FinancialDataManager:
             logger.warning("DSPy formatting failed, falling back to Gemini")
 
         if not records:
+            if unrecognized_items:
+                items_str = ", ".join(f"'{i}'" for i in unrecognized_items)
+                msg = f"The metric(s) {items_str} are not available in our dataset."
+                if self.metadata and self.metadata.get("standard_items"):
+                    sample = ", ".join(self.metadata["standard_items"][:20])
+                    msg += f" Available metrics include: {sample}."
+                if should_recommend_deep_research:
+                    msg += " For more comprehensive data you might want to try Deep Research."
+                return msg
             if should_recommend_deep_research:
                 return "No data found matching your query criteria. For more comprehensive financial information and detailed analysis, you might want to try Deep Research, our comprehensive research tool, which may have access to more granular financial data."
             else:
@@ -1182,6 +1196,24 @@ class FinancialDataManager:
                     for msg in recent_messages
                 ]
             )
+        if self.metadata:
+            available_years = ", ".join(self.metadata.get("years", []))
+            available_metrics = ", ".join(self.metadata.get("standard_items", []))
+            followup_constraint = (
+                "IMPORTANT: Only suggest follow-up questions about data the database actually contains.\n"
+                f"            Available years: {available_years}\n"
+                f"            Available metrics: {available_metrics}\n"
+                "            Valid follow-ups: a different year from the list above, a different metric "
+                "from the list above, or comparing a different company/symbol.\n"
+                "            Do NOT suggest share prices, dividends per share, analyst ratings, or any "
+                "metric not in the available metrics list."
+            )
+        else:
+            followup_constraint = (
+                "IMPORTANT: Only suggest follow-up questions about data you have seen returned above.\n"
+                "            Do NOT suggest share prices, dividends per share, or any metric "
+                "not already shown in the results."
+            )
         prompt = f"""
             Create a concise, informative response to the user's financial data query.
             {'This is a follow-up question in an ongoing conversation.' if is_follow_up else ''}
@@ -1201,13 +1233,8 @@ class FinancialDataManager:
             5. {"Maintains conversational continuity" if is_follow_up else "Sets up potential follow-up questions"}
             {"6. IMPORTANT: Include a recommendation to try 'Deep Research, our comprehensive research tool' for more detailed financial information, as the current data may be limited for this type of query." if should_recommend_deep_research else ""}
 
-            IMPORTANT: Only suggest follow-up questions about querying financial data from the database.
+            {followup_constraint}
             Do NOT suggest creating charts, performing calculations, generating reports, or any other actions.
-            Valid follow-up suggestions include:
-            - Asking about different years (e.g., "What about 2022?" or "How did this compare in 2021?")
-            - Asking about different financial metrics (revenue, profit margins, ratios, etc.)
-            - Asking for comparative analysis between companies or time periods
-            - Asking about specific financial items not yet shown
 
             Keep the response concise but informative. Be conversational and natural.
         """

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -735,6 +735,7 @@ async def fast_chat_v2(
             filters.interpretation,
             filters.is_follow_up,
             request.conversation_history,
+            unrecognized_items=filters.unrecognized_items or None,
         )
         # logger.info(f"ai_response type: {type(ai_response)}, ai_response: {ai_response}")
         data_preview = results if results else None

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -200,6 +200,9 @@ class FinancialDataFilters(BaseModel):
     data_availability_note: str = Field(default="", description="Notes about data availability")
     is_follow_up: bool = Field(default=False, description="Whether this is a follow-up query")
     context_used: str = Field(default="", description="Context used from previous queries")
+    unrecognized_items: List[str] = Field(
+        default=[], description="Requested metrics not found in the dataset"
+    )
 
 
 class FinancialDataRecord(BaseModel):

--- a/fastapi_app/app/streaming_financial_chat.py
+++ b/fastapi_app/app/streaming_financial_chat.py
@@ -100,6 +100,7 @@ async def _process_financial_chat_async(
             filters.interpretation,
             filters.is_follow_up,
             request.conversation_history,
+            unrecognized_items=filters.unrecognized_items or None,
         )
 
         await tracker.emit_progress("finalizing", "Finalizing response...", 95.0)


### PR DESCRIPTION
## Summary

- The Gemini response prompt now builds follow-up constraints at runtime from `self.metadata` (actual `standard_items` and `years` loaded from BigQuery), replacing the hardcoded list that included metrics like share prices that the dataset doesn't carry.
- `_post_process_filters` now tracks which `standard_items` were stripped as invalid and stores them in `FinancialDataFilters.unrecognized_items`.
- `format_response` uses `unrecognized_items` to return an explicit *"metric X is not available in our dataset — available metrics include …"* message instead of the generic "no data found", preventing the circular conversation pattern.

## Affected personas

`dividend_income_investor`, `technical_trader_market_data`, `investor_compare_ncb_vs_jmmb`

## Test plan

- [ ] Run simulation suite against the three affected personas and confirm circular-conversation score improves
- [ ] Confirm `unrecognized_items` message fires correctly when a metric outside the BQ schema is requested
- [ ] Confirm valid queries are unaffected (no regression on positive personas)

Closes ATS-333

🤖 Generated with [Claude Code](https://claude.com/claude-code)