### PR TITLE
feat(scripts): add script to push .env secrets to AWS SSM Parameter Store

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -123,6 +123,22 @@
     }
   ],
   "results": {
+    "Taskfile.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "Taskfile.yml",
+        "hashed_secret": "86599b4b9e48776c21458c5fd04c6f8596475438",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "Taskfile.yml",
+        "hashed_secret": "dc867c03d6f1f4385a2475b4be1137e585036dd1",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
     "docs/PHASE1_COMPLETION_SUMMARY.md": [
       {
         "type": "AWS Access Key",
@@ -130,6 +146,24 @@
         "hashed_secret": "0d8cc3c1957ebc9fdaf5319ca98960302d4087d6",
         "is_verified": false,
         "line_number": 47
+      }
+    ],
+    "docs/superpowers/plans/2026-05-31-ats-334-agentv2-financial-tool.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/superpowers/plans/2026-05-31-ats-334-agentv2-financial-tool.md",
+        "hashed_secret": "1db4aba2bc9d400d5e75f5473ff811cd819a436d",
+        "is_verified": false,
+        "line_number": 1209
+      }
+    ],
+    "evals/config/default.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "evals/config/default.yaml",
+        "hashed_secret": "1db4aba2bc9d400d5e75f5473ff811cd819a436d",
+        "is_verified": false,
+        "line_number": 14
       }
     ],
     "fastapi_app/docs/COPILOT_DEPLOYMENT_GUIDE.md": [
@@ -150,13 +184,73 @@
         "line_number": 20
       }
     ],
+    "fastapi_app/tests/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "fastapi_app/tests/conftest.py",
+        "hashed_secret": "2e3114968ebf8392cfb9b8f1940fd3829221043f",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "fastapi_app/tests/conftest.py",
+        "hashed_secret": "99058ec339b1b2f2be89b0d34cf56da97fd533c6",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "fastapi_app/tests/conftest.py",
+        "hashed_secret": "efeb28d2cd8f3790cee38a418822e73d57c705c4",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "fastapi_app/tests/conftest.py",
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "fastapi_app/tests/conftest.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
+    "fastapi_app/tests/integration/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "fastapi_app/tests/integration/conftest.py",
+        "hashed_secret": "2e3114968ebf8392cfb9b8f1940fd3829221043f",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "fastapi_app/tests/integration/conftest.py",
+        "hashed_secret": "99058ec339b1b2f2be89b0d34cf56da97fd533c6",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "fastapi_app/tests/integration/conftest.py",
+        "hashed_secret": "efeb28d2cd8f3790cee38a418822e73d57c705c4",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
     "fastapi_app/tests/test_async_s3_downloads.py": [
       {
         "type": "Secret Keyword",
         "filename": "fastapi_app/tests/test_async_s3_downloads.py",
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 95
       }
     ],
     "fastapi_app/tests/test_cache_optimization.py": [
@@ -165,7 +259,7 @@
         "filename": "fastapi_app/tests/test_cache_optimization.py",
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
-        "line_number": 267
+        "line_number": 266
       }
     ],
     "mock_client/mock_server.py": [
@@ -178,5 +272,5 @@
       }
     ]
   },
-  "generated_at": "2025-12-16T11:17:30Z"
+  "generated_at": "2026-08-07T00:26:01Z"
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,100 @@
+version: '3'
+
+vars:
+  AWS_PROFILE: 'ats-elroy'
+  APP_NAME: 'jse-datasphere-chatbot'
+
+tasks:
+  default:
+    desc: List all available tasks
+    cmds:
+      - task --list
+
+  # ---------------------------------------------------------------------------
+  # Secrets Management
+  # ---------------------------------------------------------------------------
+  secrets:push:  # pragma: allowlist secret
+    desc: "Push secrets from .env to AWS SSM Parameter Store for an environment (e.g. task secrets:push ENV=dev)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    cmds:
+      - ./venv/bin/python3 scripts/push_copilot_secrets.py --env {{.ENV}} --app {{.APP_NAME}} --profile {{.AWS_PROFILE}}
+
+  secrets:dev:  # pragma: allowlist secret
+    desc: Push secrets to dev environment
+    cmds:
+      - task: secrets:push
+        vars: {ENV: dev}
+
+  secrets:prod:  # pragma: allowlist secret
+    desc: Push secrets to prod environment
+    cmds:
+      - task: secrets:push
+        vars: {ENV: prod}
+
+  # ---------------------------------------------------------------------------
+  # Copilot Environment Management
+  # ---------------------------------------------------------------------------
+  env:init:
+    desc: "Initialize a Copilot environment (e.g. task env:init ENV=dev)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    dir: fastapi_app
+    cmds:
+      - AWS_PROFILE={{.AWS_PROFILE}} copilot env init --name {{.ENV}} --profile {{.AWS_PROFILE}} --default-config
+
+  env:deploy:
+    desc: "Deploy a Copilot environment (e.g. task env:deploy ENV=dev)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+    dir: fastapi_app
+    cmds:
+      - AWS_PROFILE={{.AWS_PROFILE}} copilot env deploy --name {{.ENV}}
+
+  # ---------------------------------------------------------------------------
+  # Service Deployment Tasks
+  # ---------------------------------------------------------------------------
+  deploy:
+    desc: "Deploy service to a specified environment, pushing secrets first (e.g. task deploy ENV=dev)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+      SERVICE: '{{.SERVICE | default "api"}}'
+    cmds:
+      - ./venv/bin/python3 scripts/push_copilot_secrets.py --env {{.ENV}} --app {{.APP_NAME}} --profile {{.AWS_PROFILE}}
+      - cd fastapi_app && AWS_PROFILE={{.AWS_PROFILE}} copilot svc deploy --name {{.SERVICE}} --env {{.ENV}}
+
+  deploy:dev:
+    desc: Deploy api service to dev environment (pushes secrets automatically)
+    cmds:
+      - task: deploy
+        vars: {ENV: dev, SERVICE: api}
+
+  deploy:prod:
+    desc: Deploy api service to prod environment (pushes secrets automatically)
+    cmds:
+      - task: deploy
+        vars: {ENV: prod, SERVICE: api}
+
+  # ---------------------------------------------------------------------------
+  # Status and Info
+  # ---------------------------------------------------------------------------
+  status:
+    desc: "Show Copilot service status (e.g. task status ENV=dev)"
+    vars:
+      ENV: '{{.ENV | default "dev"}}'
+      SERVICE: '{{.SERVICE | default "api"}}'
+    dir: fastapi_app
+    cmds:
+      - AWS_PROFILE={{.AWS_PROFILE}} copilot svc show --name {{.SERVICE}}
+
+  status:dev:
+    desc: Show dev service status and endpoint
+    cmds:
+      - task: status
+        vars: {ENV: dev, SERVICE: api}
+
+  status:prod:
+    desc: Show prod service status and endpoint
+    cmds:
+      - task: status
+        vars: {ENV: prod, SERVICE: api}

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -286,30 +286,32 @@ async def health_check():
         # Check S3 connectivity
         s3_health = await _check_s3_health()
         health_status["components"]["s3"] = s3_health
-        if s3_health["status"] != "healthy":
+        if s3_health["status"] == "unhealthy":
             all_healthy = False
 
         # Check BigQuery connectivity
+        # Only "unhealthy" (client crashed) blocks overall health.
+        # "unavailable" or "degraded" means a graceful partial failure — service still runs.
         bigquery_health = await _check_bigquery_health()
         health_status["components"]["bigquery"] = bigquery_health
-        if bigquery_health["status"] != "healthy":
+        if bigquery_health["status"] == "unhealthy":
             all_healthy = False
 
-        # Check Redis connectivity
+        # Check Redis connectivity (optional — never blocks health)
         redis_health = await _check_redis_health()
         health_status["components"]["redis"] = redis_health
-        # Redis is optional, so don't mark overall health as unhealthy if Redis is down
 
         # Check Gemini AI availability
         gemini_health = await _check_gemini_health()
         health_status["components"]["gemini"] = gemini_health
-        if gemini_health["status"] != "healthy":
+        if gemini_health["status"] == "unhealthy":
             all_healthy = False
 
         # Check metadata availability
+        # "unavailable" means S3 metadata load failed — degraded but not critical.
         metadata_health = _check_metadata_health()
         health_status["components"]["metadata"] = metadata_health
-        if metadata_health["status"] != "healthy":
+        if metadata_health["status"] == "unhealthy":
             all_healthy = False
 
         # Set overall status

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -286,32 +286,30 @@ async def health_check():
         # Check S3 connectivity
         s3_health = await _check_s3_health()
         health_status["components"]["s3"] = s3_health
-        if s3_health["status"] == "unhealthy":
+        if s3_health["status"] != "healthy":
             all_healthy = False
 
         # Check BigQuery connectivity
-        # Only "unhealthy" (client crashed) blocks overall health.
-        # "unavailable" or "degraded" means a graceful partial failure — service still runs.
         bigquery_health = await _check_bigquery_health()
         health_status["components"]["bigquery"] = bigquery_health
-        if bigquery_health["status"] == "unhealthy":
+        if bigquery_health["status"] != "healthy":
             all_healthy = False
 
-        # Check Redis connectivity (optional — never blocks health)
+        # Check Redis connectivity
         redis_health = await _check_redis_health()
         health_status["components"]["redis"] = redis_health
+        # Redis is optional, so don't mark overall health as unhealthy if Redis is down
 
         # Check Gemini AI availability
         gemini_health = await _check_gemini_health()
         health_status["components"]["gemini"] = gemini_health
-        if gemini_health["status"] == "unhealthy":
+        if gemini_health["status"] != "healthy":
             all_healthy = False
 
         # Check metadata availability
-        # "unavailable" means S3 metadata load failed — degraded but not critical.
         metadata_health = _check_metadata_health()
         health_status["components"]["metadata"] = metadata_health
-        if metadata_health["status"] == "unhealthy":
+        if metadata_health["status"] != "healthy":
             all_healthy = False
 
         # Set overall status

--- a/scripts/push_copilot_secrets.py
+++ b/scripts/push_copilot_secrets.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Push secrets from a .env file to AWS Systems Manager (SSM) Parameter Store
+for AWS Copilot services.
+"""
+
+import argparse
+import os
+import sys
+import boto3
+from dotenv import dotenv_values
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Push environment secrets from .env file to AWS SSM Parameter Store for AWS Copilot."
+    )
+    parser.add_argument(
+        "--env",
+        default="dev",
+        help="Copilot environment name (e.g. dev, test, staging, prod). Default: dev",
+    )
+    parser.add_argument(
+        "--app",
+        default="jse-datasphere-chatbot",
+        help="Copilot application name. Default: jse-datasphere-chatbot",
+    )
+    parser.add_argument(
+        "--profile",
+        default=os.environ.get("AWS_PROFILE", "ats-elroy"),
+        help="AWS CLI Profile name to use. Default: $AWS_PROFILE or 'ats-elroy'",
+    )
+    parser.add_argument(
+        "--region",
+        default=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+        help="AWS Region. Default: us-east-1",
+    )
+    parser.add_argument(
+        "--env-file",
+        default="fastapi_app/.env",
+        help="Path to the .env file containing secret variables. Default: fastapi_app/.env",
+    )
+
+    args = parser.parse_args()
+
+    env_path = os.path.abspath(args.env_file)
+    if not os.path.exists(env_path):
+        print(f"Error: .env file not found at '{env_path}'", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Reading environment variables from '{env_path}'...")
+    env_vars = dotenv_values(env_path)
+
+    session = boto3.Session(profile_name=args.profile, region_name=args.region)
+    ssm = session.client("ssm")
+
+    secret_keys = [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "GOOGLE_API_KEY",
+        "GCP_SERVICE_ACCOUNT_INFO",
+    ]
+
+    pushed_count = 0
+    for key in secret_keys:
+        val = env_vars.get(key)
+        if not val:
+            print(f"⚠️  Skipping {key}: Not found in {env_path}")
+            continue
+
+        param_name = f"/copilot/{args.app}/{args.env}/secrets/{key}"
+        print(f"Pushing '{key}' -> SSM: {param_name}...")
+        try:
+            ssm.put_parameter(
+                Name=param_name,
+                Value=val,
+                Type="SecureString",
+                Overwrite=True,
+            )
+            print(f"✅ Successfully pushed {key}")
+            pushed_count += 1
+        except Exception as e:
+            print(f"❌ Failed to push {key}: {e}", file=sys.stderr)
+
+    print(f"\nDone! Pushed {pushed_count} secret(s) to AWS SSM Parameter Store.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/push_copilot_secrets.py
+++ b/scripts/push_copilot_secrets.py
@@ -77,7 +77,15 @@ def main():
                 Type="SecureString",
                 Overwrite=True,
             )
-            print(f"✅ Successfully pushed {key}")
+            ssm.add_tags_to_resource(
+                ResourceType="Parameter",
+                ResourceId=param_name,
+                Tags=[
+                    {"Key": "copilot-application", "Value": args.app},
+                    {"Key": "copilot-environment", "Value": args.env},
+                ],
+            )
+            print(f"✅ Successfully pushed and tagged {key}")
             pushed_count += 1
         except Exception as e:
             print(f"❌ Failed to push {key}: {e}", file=sys.stderr)


### PR DESCRIPTION
Adds a CLI helper script  to sync secret environment variables from a  file to AWS SSM Parameter Store as  parameters for AWS Copilot deployments.

### Features
- Configurable environment (), application (), AWS profile (), AWS region (), and env file ()
- Automatically formats parameter names as 
- Uses  and  to parse  and store as  in SSM