### PR TITLE
Add response caching, BigQuery interaction logging, and Langfuse tracing

### DIFF
--- a/docs/CACHING_LOGGING_TRACING.md
+++ b/docs/CACHING_LOGGING_TRACING.md
@@ -1,0 +1,77 @@
+# Response Caching, Interaction Logging & Tracing
+
+Applies to the two production endpoints, `POST /fast_chat_v2` and `POST
+/chat/stream` (`fastapi_app/app/main.py`). `/chat` (S3 document RAG) is not
+covered.
+
+## What each piece does
+
+- **Response cache** (`fastapi_app/app/response_cache.py`, Redis-backed): skips
+  the Gemini call entirely for a repeated/identical query, cutting cost and
+  latency. Phase 1 only — normalized exact-string match, no semantic
+  similarity. Cache is skipped whenever `conversation_history` is present
+  (a follow-up's correct answer depends on that context), and for
+  `chat_stream` the cache key also includes `enable_web_search`/
+  `enable_financial_data` since those change which tools run. No-ops safely
+  if Redis isn't configured.
+- **Interaction logging** (`fastapi_app/app/interaction_log.py`, BigQuery):
+  the permanent record of every call (success and failure) — query,
+  response, tokens, cost, latency, cache hit/miss — used for
+  regression/behavior monitoring. Chosen over relying on Langfuse's own
+  (time-limited) trace retention. Fires via `asyncio.create_task(...)` so a
+  logging failure never affects the user-facing request or its latency.
+- **Langfuse tracing** (`fastapi_app/app/tracing.py`): trace-level
+  observability and cost dashboards only — not used for caching (Langfuse
+  doesn't do response caching) and not the permanent log (BigQuery is). No-ops
+  safely if `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` aren't set.
+
+## New environment variables
+
+See `fastapi_app/.env.example` for the full list with defaults
+(`RESPONSE_CACHE_*`, `INTERACTION_LOGGING_ENABLED`, `BIGQUERY_INTERACTIONS_*`,
+`LANGFUSE_*`). `REDIS_URL` is already handled by the existing ElastiCache
+Copilot addon (`fastapi_app/copilot/examples/api/addons/redis.yml.example`) —
+no new Redis-specific env var was added.
+
+## One-time setup a human needs to do (cannot be run from a sandboxed session)
+
+1. **Langfuse**: sign up for Langfuse Cloud (free Hobby tier is fine to
+   start — traces retained 30 days; see the tradeoff note below), create a
+   project, copy the Public/Secret keys.
+2. **Create the BigQuery `interactions` table** (idempotent, safe to re-run):
+   ```bash
+   python scripts/create_interactions_table.py \
+     --project <GCP_PROJECT_ID> --dataset <BIGQUERY_DATASET> \
+     --table interactions --location <BIGQUERY_LOCATION>
+   ```
+3. **Push the two new secrets to SSM**, per environment, after adding
+   `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` to your local `fastapi_app/.env`
+   (the script already includes them in its `secret_keys` list):
+   ```bash
+   python scripts/push_copilot_secrets.py --env staging --profile ats-jse-elroy --env-file fastapi_app/.env
+   ```
+4. **Populate the real (gitignored) Copilot manifest**: copy
+   `fastapi_app/copilot/examples/api/manifest.yml.example` into
+   `fastapi_app/copilot/api/manifest.yml` if you haven't already, uncomment
+   the two new `LANGFUSE_*` lines in `secrets:`, and fill in the new plain
+   `variables:` (cache TTL, table names, etc.) per environment.
+5. **Confirm the Redis ElastiCache addon is actually deployed** — a template
+   existing at `redis.yml.example` doesn't mean it's live in a given
+   environment. Check `copilot svc show --name api --env staging` or the
+   environment's CloudFormation stack Outputs for `RedisUrl`. If missing,
+   copy `redis.yml.example` to the real `copilot/api/addons/redis.yml` before
+   deploying.
+6. **Deploy**: `copilot svc deploy --name api --env staging --profile ats-jse-elroy` (repeat per environment).
+7. **Smoke test**: send the same `/fast_chat_v2` or `/chat/stream` query
+   twice with no conversation history — the second call should be
+   noticeably faster and should not appear as a fresh Gemini call in
+   Langfuse. Check the Langfuse Cloud dashboard for traces and the BigQuery
+   console for new rows in `interactions`.
+
+## Known limitation
+
+Langfuse's free Hobby tier only retains trace data for 30 days, with no
+built-in export to a data warehouse (that requires a paid add-on). This is
+why BigQuery, not Langfuse, is the permanent interaction-log store — Langfuse
+is purely for the trace UI and cost dashboards, which don't need to be
+permanent.

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -26,6 +26,8 @@ The following secrets are stored in AWS Systems Manager Parameter Store:
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key for S3 access | SecureString |
 | `GOOGLE_API_KEY` | Google Gemini AI API key | SecureString |
 | `GCP_SERVICE_ACCOUNT_INFO` | GCP service account JSON (contains private key) | SecureString |
+| `LANGFUSE_PUBLIC_KEY` | Langfuse project public key (tracing/dashboards) | SecureString |
+| `LANGFUSE_SECRET_KEY` | Langfuse project secret key (tracing/dashboards) | SecureString |
 
 ### Parameter Store Paths
 

--- a/fastapi_app/.env.example
+++ b/fastapi_app/.env.example
@@ -50,3 +50,25 @@ ASYNC_JOB_TTL_SECONDS=900
 
 # Maximum number of progress updates to keep in history (default: 50)
 ASYNC_JOB_MAX_PROGRESS_HISTORY=50
+
+# Redis (ElastiCache addon injects REDIS_URL/RedisUrl/REDISURL automatically in AWS;
+# set explicitly for local dev, e.g. redis://localhost:6379/0)
+REDIS_URL=
+
+# Response cache (fast_chat_v2 / chat_stream), backed by Redis above.
+# Skipped whenever conversation_history is present, and no-ops if REDIS_URL is unset.
+RESPONSE_CACHE_ENABLED=true
+RESPONSE_CACHE_TTL_SECONDS=3600
+
+# Permanent interaction logging to BigQuery (fast_chat_v2 / chat_stream).
+# Table must already exist - see scripts/create_interactions_table.py.
+INTERACTION_LOGGING_ENABLED=true
+BIGQUERY_INTERACTIONS_TABLE=interactions
+# BIGQUERY_INTERACTIONS_DATASET=<YOUR_BIGQUERY_DATASET>  # defaults to BIGQUERY_DATASET if unset
+
+# Langfuse tracing/dashboards (cost visibility only - not used for caching or
+# permanent logging). No-ops when keys are unset.
+LANGFUSE_ENABLED=true
+LANGFUSE_PUBLIC_KEY="<YOUR_LANGFUSE_PUBLIC_KEY>"
+LANGFUSE_SECRET_KEY="<YOUR_LANGFUSE_SECRET_KEY>"
+LANGFUSE_HOST=https://cloud.langfuse.com

--- a/fastapi_app/app/agent_v2.py
+++ b/fastapi_app/app/agent_v2.py
@@ -20,6 +20,7 @@ from app.financial_tool import build_financial_context, query_and_run
 from app.gemini_client import get_genai_client
 from app.logging_config import get_logger
 from app.models import CostSummary, PhaseCost
+from app.tracing import log_completed_generation
 from app.utils.cost_tracking import calculate_cost_from_response
 from app.utils.monitoring import record_ai_cost
 from app.utils.prompt_cache import PromptCache
@@ -204,6 +205,15 @@ class AgentV2:
             output_cost=cost.output_cost,
             total_cost=cost.total_cost,
             cached_tokens=cost.token_usage.cached_tokens,
+        )
+        log_completed_generation(
+            phase,
+            model=model,
+            output=getattr(response, "text", None),
+            usage_details={
+                "input": cost.token_usage.input_tokens,
+                "output": cost.token_usage.output_tokens,
+            },
         )
         self._add_phase_cost(
             phase=phase,

--- a/fastapi_app/app/config.py
+++ b/fastapi_app/app/config.py
@@ -74,6 +74,18 @@ class BigQueryConfig(BaseSettings):
     dataset: str = Field(..., description="BigQuery dataset name")
     table: str = Field(..., description="BigQuery table name")
     location: str = Field(default="US", description="BigQuery location")
+    interactions_table: str = Field(
+        default="interactions", description="BigQuery table for permanent interaction logging"
+    )
+    interactions_dataset: Optional[str] = Field(
+        default=None,
+        description="BigQuery dataset for interaction logging (falls back to `dataset` if unset)",
+    )
+    logging_enabled: bool = Field(
+        default=True,
+        alias="INTERACTION_LOGGING_ENABLED",
+        description="Whether to write interaction logs to BigQuery",
+    )
 
     model_config = SettingsConfigDict(
         env_prefix="BIGQUERY_",
@@ -82,6 +94,11 @@ class BigQueryConfig(BaseSettings):
         case_sensitive=False,
         extra="ignore",  # Ignore extra environment variables
     )
+
+    @property
+    def resolved_interactions_dataset(self) -> str:
+        """The dataset interaction logs should be written to."""
+        return self.interactions_dataset or self.dataset
 
 
 class RedisConfig(BaseSettings):
@@ -93,6 +110,16 @@ class RedisConfig(BaseSettings):
     )
     ttl_seconds: int = Field(default=900, description="TTL for job data in seconds")
     max_progress_history: int = Field(default=50, description="Max progress updates to retain")
+    response_cache_ttl_seconds: int = Field(
+        default=3600,
+        alias="RESPONSE_CACHE_TTL_SECONDS",
+        description="TTL for cached endpoint responses in seconds",
+    )
+    response_cache_enabled: bool = Field(
+        default=True,
+        alias="RESPONSE_CACHE_ENABLED",
+        description="Manual kill switch for the response cache, independent of Redis connectivity",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -116,6 +143,31 @@ class RedisConfig(BaseSettings):
         if v:
             return v
         return os.getenv("REDIS_URL") or os.getenv("RedisUrl") or os.getenv("REDISURL")
+
+
+class LangfuseConfig(BaseSettings):
+    """Langfuse tracing/observability configuration. No-ops when keys are unset."""
+
+    public_key: Optional[str] = Field(default=None, alias="LANGFUSE_PUBLIC_KEY")
+    secret_key: Optional[str] = Field(default=None, alias="LANGFUSE_SECRET_KEY")
+    host: str = Field(default="https://cloud.langfuse.com", alias="LANGFUSE_HOST")
+    enabled: bool = Field(
+        default=True,
+        alias="LANGFUSE_ENABLED",
+        description="Manual kill switch, independent of whether keys are configured",
+    )
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",  # Ignore extra environment variables
+    )
+
+    @property
+    def configured(self) -> bool:
+        """Whether tracing should actually be initialized (enabled + keys present)."""
+        return bool(self.enabled and self.public_key and self.secret_key)
 
 
 class S3DownloadConfig(BaseSettings):
@@ -200,6 +252,7 @@ class AppConfig(BaseSettings):
     s3_download: S3DownloadConfig = Field(default_factory=S3DownloadConfig)
     gemini: GeminiAIConfig = Field(default_factory=GeminiAIConfig)
     async_job: AsyncJobConfig = Field(default_factory=AsyncJobConfig)
+    langfuse: LangfuseConfig = Field(default_factory=LangfuseConfig)
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -18,6 +18,8 @@ from app.dspy_modules import (
 from app.gemini_client import get_genai_client
 from app.logging_config import get_logger
 from app.models import FinancialDataFilters, FinancialDataRecord
+from app.tracing import traced_observation
+from app.utils.cost_tracking import CostResult, calculate_cost_from_response
 from app.utils.monitoring import record_ai_request, record_bigquery_query
 from app.utils.prompt_cache import PromptCache
 
@@ -514,6 +516,7 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
         query: str,
         conversation_history: Optional[List[Dict[str, str]]] = None,
         last_query_data: Optional[Dict] = None,
+        cost_sink: Optional[List[CostResult]] = None,
     ) -> FinancialDataFilters:
         """Use DSPy or Gemini to parse user query and extract filter parameters with conversation context"""
 
@@ -542,30 +545,47 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
         try:
             response = None
             cache_name = _PARSE_QUERY_CACHE.get_cache_name(system_instruction)
-            if cache_name:
-                try:
-                    client = get_genai_client()
-                    response = client.models.generate_content(
-                        model=model_name,
-                        contents=[
-                            genai_types.Content(
-                                role="user",
-                                parts=[genai_types.Part.from_text(text=dynamic_content)],
-                            )
-                        ],
-                        config=genai_types.GenerateContentConfig(cached_content=cache_name),
+            with traced_observation(
+                "parse_user_query", as_type="generation", model=model_name, input=dynamic_content
+            ) as gen:
+                if cache_name:
+                    try:
+                        client = get_genai_client()
+                        response = client.models.generate_content(
+                            model=model_name,
+                            contents=[
+                                genai_types.Content(
+                                    role="user",
+                                    parts=[genai_types.Part.from_text(text=dynamic_content)],
+                                )
+                            ],
+                            config=genai_types.GenerateContentConfig(cached_content=cache_name),
+                        )
+                    except Exception as cache_exc:
+                        logger.warning(
+                            "cached_query_parsing_failed_falling_back",
+                            extra={"error": str(cache_exc)},
+                        )
+                if not response:
+                    # Fallback: combine into one prompt and use the legacy model
+                    prompt = f"{system_instruction}\n\n{dynamic_content}"
+                    response = self.model.generate_content(prompt)
+                response_text = response.text.strip()
+                duration = time.time() - start_time
+
+                cost_result = calculate_cost_from_response(
+                    model_name, response, phase="parse_user_query"
+                )
+                if cost_sink is not None:
+                    cost_sink.append(cost_result)
+                if gen is not None:
+                    gen.update(
+                        output=response_text,
+                        usage_details={
+                            "input": cost_result.token_usage.input_tokens,
+                            "output": cost_result.token_usage.output_tokens,
+                        },
                     )
-                except Exception as cache_exc:
-                    logger.warning(
-                        "cached_query_parsing_failed_falling_back",
-                        extra={"error": str(cache_exc)},
-                    )
-            if not response:
-                # Fallback: combine into one prompt and use the legacy model
-                prompt = f"{system_instruction}\n\n{dynamic_content}"
-                response = self.model.generate_content(prompt)
-            response_text = response.text.strip()
-            duration = time.time() - start_time
 
             # Clean up the response - remove markdown code blocks if present
             if response_text.startswith("```json"):
@@ -651,8 +671,8 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
                 model=model_name,
                 duration=duration,
                 success=True,
-                input_tokens=None,
-                output_tokens=None,
+                input_tokens=cost_result.token_usage.input_tokens,
+                output_tokens=cost_result.token_usage.output_tokens,
             )
 
             return FinancialDataFilters(**result)
@@ -1189,6 +1209,7 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
         is_follow_up: bool = False,
         conversation_history: Optional[List[Dict[str, str]]] = None,
         unrecognized_items: Optional[List[str]] = None,
+        cost_sink: Optional[List[CostResult]] = None,
     ) -> str:
         """Format the query results into a readable response with conversation awareness"""
 
@@ -1279,11 +1300,39 @@ Do NOT provide any analysis, data, or commentary regarding share prices, dividen
 
             Keep the response concise but informative. Be conversational and natural.
         """
+        model_name = os.getenv("GEMINI_MODEL_NAME", "gemini-2.5-flash")
+        start_time = time.time()
         try:
-            response = self.model.generate_content(prompt)
+            with traced_observation(
+                "format_response", as_type="generation", model=model_name, input=prompt
+            ) as gen:
+                response = self.model.generate_content(prompt)
+                duration = time.time() - start_time
+                cost_result = calculate_cost_from_response(
+                    model_name, response, phase="format_response"
+                )
+                if cost_sink is not None:
+                    cost_sink.append(cost_result)
+                if gen is not None:
+                    gen.update(
+                        output=response.text,
+                        usage_details={
+                            "input": cost_result.token_usage.input_tokens,
+                            "output": cost_result.token_usage.output_tokens,
+                        },
+                    )
+            record_ai_request(
+                model=model_name,
+                duration=duration,
+                success=True,
+                input_tokens=cost_result.token_usage.input_tokens,
+                output_tokens=cost_result.token_usage.output_tokens,
+            )
             return response.text
         except Exception as e:
+            duration = time.time() - start_time
             logger.error(f"Error generating AI response: {e}")
+            record_ai_request(model=model_name, duration=duration, success=False)
             # Fallback to basic formatting
             return (
                 f"Found {len(records)} records matching your query. Here's a summary of the data."

--- a/fastapi_app/app/interaction_log.py
+++ b/fastapi_app/app/interaction_log.py
@@ -1,0 +1,168 @@
+"""
+Permanent interaction logging to BigQuery.
+
+Every call to /fast_chat_v2 and /chat/stream is logged here (success and
+failure) as the permanent record for regression/behavior monitoring, chosen
+over relying on Langfuse's own (time-limited) trace retention.
+
+Logging failures must never affect the user-facing request: `.log()` never
+raises, and callers are expected to fire it via `asyncio.create_task(...)`
+rather than awaiting it inline on the request path.
+"""
+
+import asyncio
+import json
+import uuid
+from typing import Any, Dict, Optional
+
+from google.cloud import bigquery
+from google.oauth2 import service_account
+
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Schema for the `interactions` table. Kept alongside the writer so the
+# table-creation script and the writer never drift apart.
+INTERACTIONS_SCHEMA = [
+    bigquery.SchemaField("interaction_id", "STRING", mode="REQUIRED"),
+    bigquery.SchemaField("request_id", "STRING", mode="NULLABLE"),
+    bigquery.SchemaField("endpoint", "STRING", mode="REQUIRED"),
+    bigquery.SchemaField("timestamp", "TIMESTAMP", mode="REQUIRED"),
+    bigquery.SchemaField("query", "STRING", mode="REQUIRED"),
+    bigquery.SchemaField("response", "STRING", mode="NULLABLE"),
+    bigquery.SchemaField("conversation_history_json", "STRING", mode="NULLABLE"),
+    bigquery.SchemaField("memory_enabled", "BOOLEAN", mode="NULLABLE"),
+    bigquery.SchemaField("enable_web_search", "BOOLEAN", mode="NULLABLE"),
+    bigquery.SchemaField("enable_financial_data", "BOOLEAN", mode="NULLABLE"),
+    bigquery.SchemaField("model", "STRING", mode="NULLABLE"),
+    bigquery.SchemaField("input_tokens", "INTEGER", mode="NULLABLE"),
+    bigquery.SchemaField("output_tokens", "INTEGER", mode="NULLABLE"),
+    bigquery.SchemaField("total_tokens", "INTEGER", mode="NULLABLE"),
+    bigquery.SchemaField("cost_usd", "FLOAT", mode="NULLABLE"),
+    bigquery.SchemaField("phase_costs_json", "STRING", mode="NULLABLE"),
+    bigquery.SchemaField("latency_ms", "FLOAT", mode="NULLABLE"),
+    bigquery.SchemaField("cache_hit", "BOOLEAN", mode="REQUIRED"),
+    bigquery.SchemaField("data_found", "BOOLEAN", mode="NULLABLE"),
+    bigquery.SchemaField("record_count", "INTEGER", mode="NULLABLE"),
+    bigquery.SchemaField("success", "BOOLEAN", mode="REQUIRED"),
+    bigquery.SchemaField("error_message", "STRING", mode="NULLABLE"),
+]
+
+
+class InteractionLogger:
+    """Fire-and-forget writer for the permanent `interactions` BigQuery table."""
+
+    def __init__(
+        self,
+        bq_client: Optional[bigquery.Client],
+        dataset: Optional[str],
+        table: str,
+        enabled: bool = True,
+    ):
+        self._client = bq_client
+        self._table_ref = f"{dataset}.{table}" if bq_client and dataset else None
+        self._enabled = bool(enabled and bq_client is not None and self._table_ref)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @staticmethod
+    def build_row(
+        *,
+        endpoint: str,
+        query: str,
+        response: Optional[str],
+        request_id: Optional[str] = None,
+        conversation_history: Optional[list] = None,
+        memory_enabled: Optional[bool] = None,
+        enable_web_search: Optional[bool] = None,
+        enable_financial_data: Optional[bool] = None,
+        model: Optional[str] = None,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cost_usd: float = 0.0,
+        phase_costs: Optional[Any] = None,
+        latency_ms: Optional[float] = None,
+        cache_hit: bool = False,
+        data_found: Optional[bool] = None,
+        record_count: Optional[int] = None,
+        success: bool = True,
+        error_message: Optional[str] = None,
+        timestamp: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Build a row dict matching INTERACTIONS_SCHEMA. Caller supplies `timestamp`
+        (ISO string) since this module avoids datetime.now() for testability."""
+        return {
+            "interaction_id": uuid.uuid4().hex,
+            "request_id": request_id,
+            "endpoint": endpoint,
+            "timestamp": timestamp,
+            "query": query,
+            "response": response,
+            "conversation_history_json": (
+                json.dumps(conversation_history, default=str) if conversation_history else None
+            ),
+            "memory_enabled": memory_enabled,
+            "enable_web_search": enable_web_search,
+            "enable_financial_data": enable_financial_data,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": (input_tokens or 0) + (output_tokens or 0),
+            "cost_usd": cost_usd,
+            "phase_costs_json": json.dumps(phase_costs, default=str) if phase_costs else None,
+            "latency_ms": latency_ms,
+            "cache_hit": cache_hit,
+            "data_found": data_found,
+            "record_count": record_count,
+            "success": success,
+            "error_message": error_message,
+        }
+
+    async def log(self, row: Dict[str, Any]) -> None:
+        if not self._enabled:
+            return
+        try:
+            errors = await asyncio.to_thread(self._client.insert_rows_json, self._table_ref, [row])
+            if errors:
+                logger.error("interaction_log_insert_errors", extra={"errors": errors})
+        except Exception as exc:
+            # Never propagate — a logging failure must never affect the user-facing request.
+            logger.error("interaction_log_insert_failed", extra={"error": str(exc)})
+
+
+def _initialize_bigquery_client(project_id: Optional[str]) -> Optional[bigquery.Client]:
+    """Build a BigQuery client, mirroring financial_utils.py's auth modes."""
+    import os
+
+    credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    service_account_info = os.getenv("GCP_SERVICE_ACCOUNT_INFO")
+    try:
+        if credentials_path and os.path.exists(credentials_path):
+            return bigquery.Client.from_service_account_json(credentials_path, project=project_id)
+        if service_account_info:
+            info = json.loads(service_account_info)
+            credentials = service_account.Credentials.from_service_account_info(info)
+            return bigquery.Client(credentials=credentials, project=project_id)
+        return bigquery.Client(project=project_id)
+    except Exception as exc:
+        logger.error("interaction_log_bigquery_client_init_failed", extra={"error": str(exc)})
+        return None
+
+
+def build_interaction_logger() -> InteractionLogger:
+    """Construct an InteractionLogger from the current app config."""
+    from app.config import get_config
+
+    cfg = get_config()
+    bq_client = None
+    if cfg.bigquery.logging_enabled:
+        bq_client = _initialize_bigquery_client(cfg.gcp.project_id)
+    return InteractionLogger(
+        bq_client=bq_client,
+        dataset=cfg.bigquery.resolved_interactions_dataset,
+        table=cfg.bigquery.interactions_table,
+        enabled=cfg.bigquery.logging_enabled,
+    )

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import StreamingResponse, JSONResponse, Response
 import time
 import uuid
 import asyncio
+from datetime import datetime, timezone
 from typing import Dict, Any
 from contextlib import asynccontextmanager
 
@@ -29,6 +30,9 @@ from app.document_selector import auto_load_relevant_documents
 from app.financial_utils import FinancialDataManager
 from app.agent_v2 import AgentV2
 from app.config import get_config
+from app.response_cache import ResponseCache, build_response_cache
+from app.interaction_log import InteractionLogger, build_interaction_logger
+from app.tracing import get_langfuse_client, traced_observation
 from app.logging_config import configure_logging, get_logger
 from app.middleware.request_id import RequestIDMiddleware
 from app.middleware.metrics import (
@@ -88,11 +92,39 @@ async def lifespan(app: FastAPI):
             logger.error(f"Failed to initialize financial data manager: {financial_err}")
             app.state.financial_manager = None
 
+        # -----------------------
+        # Response cache (Redis), interaction logger (BigQuery), tracing (Langfuse)
+        # -----------------------
+        app.state.response_cache = build_response_cache()
+        logger.info(
+            "response_cache_initialized",
+            extra={"enabled": app.state.response_cache.enabled},
+        )
+
+        app.state.interaction_logger = build_interaction_logger()
+        logger.info(
+            "interaction_logger_initialized",
+            extra={"enabled": app.state.interaction_logger.enabled},
+        )
+
+        langfuse_client = get_langfuse_client()
+        logger.info("langfuse_client_initialized", extra={"enabled": langfuse_client is not None})
+
         yield
 
     except Exception as e:
         logger.error(f"Error during startup: {str(e)}")
         # We'll continue and let individual endpoints handle errors
+    finally:
+        cache = getattr(app.state, "response_cache", None)
+        if cache is not None:
+            await cache.close()
+        langfuse_client = get_langfuse_client()
+        if langfuse_client is not None:
+            try:
+                langfuse_client.flush()
+            except Exception as exc:
+                logger.warning("langfuse_flush_failed", extra={"error": str(exc)})
 
 
 # Initialize FastAPI app
@@ -188,6 +220,16 @@ def get_metadata():
 # Dependency to get financial data manager
 def get_financial_manager():
     return getattr(app.state, "financial_manager", None)
+
+
+# Dependency to get the response cache
+def get_response_cache_dep():
+    return getattr(app.state, "response_cache", None)
+
+
+# Dependency to get the interaction logger
+def get_interaction_logger_dep():
+    return getattr(app.state, "interaction_logger", None)
 
 
 @app.get("/")
@@ -490,7 +532,10 @@ async def chat(
 @app.post("/fast_chat_v2", response_model=FinancialDataResponse)
 async def fast_chat_v2(
     request: FinancialDataRequest,
+    http_request: Request,
     financial_manager: Any = Depends(get_financial_manager),
+    response_cache: Any = Depends(get_response_cache_dep),
+    interaction_logger: Any = Depends(get_interaction_logger_dep),
 ):
     """
     Natural language financial data query endpoint
@@ -503,6 +548,11 @@ async def fast_chat_v2(
 
     The endpoint uses AI to parse natural language queries into structured filters,
     queries the financial database, and returns formatted responses with data insights.
+
+    Repeated queries with no conversation history are served from a Redis
+    response cache (skipped whenever history is present, since a follow-up's
+    correct answer depends on that context). Every call is logged to BigQuery
+    for regression/behavior monitoring, and traced via Langfuse if configured.
     """
     logger.info(
         f"/fast_chat_v2 called. query='{request.query[:200]}', memory_enabled={request.memory_enabled}"
@@ -519,54 +569,160 @@ async def fast_chat_v2(
     else:
         logger.info("📜 No conversation history received")
 
+    start_time = time.time()
+    request_id = getattr(http_request.state, "request_id", None)
+    cache_eligible = not request.conversation_history
+    cache_key = (
+        ResponseCache.build_key("fast_chat_v2", ResponseCache.normalize_query(request.query))
+        if cache_eligible
+        else None
+    )
+
+    def schedule_log(**kwargs):
+        if interaction_logger is None:
+            return
+        row = InteractionLogger.build_row(
+            endpoint="fast_chat_v2",
+            query=request.query,
+            request_id=request_id,
+            conversation_history=request.conversation_history,
+            memory_enabled=request.memory_enabled,
+            latency_ms=(time.time() - start_time) * 1000,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            **kwargs,
+        )
+        asyncio.create_task(interaction_logger.log(row))
+
     try:
         if not financial_manager:
             raise HTTPException(
                 status_code=503,
                 detail="Financial data service is not available. Please ensure BigQuery is configured.",
             )
+
+        cached = await response_cache.get(cache_key) if cache_key and response_cache else None
+        if cached is not None:
+            ai_response = cached["response"]
+            data_found = cached["data_found"]
+            record_count = cached["record_count"]
+            filters = FinancialDataFilters(**cached["filters_used"])
+            data_preview = (
+                [FinancialDataRecord(**r) for r in cached["data_preview"]]
+                if cached.get("data_preview")
+                else None
+            )
+            chart_spec = ChartSpec(**cached["chart"]) if cached.get("chart") else None
+
+            updated_conversation_history = None
+            if request.memory_enabled:
+                updated_conversation_history = [
+                    {"role": "user", "content": request.query},
+                    {"role": "assistant", "content": ai_response},
+                ]
+
+            logger.info(f"/fast_chat_v2 cache hit. data_found={data_found}")
+            schedule_log(
+                response=ai_response,
+                cache_hit=True,
+                success=True,
+                data_found=data_found,
+                record_count=record_count,
+            )
+            return FinancialDataResponse(
+                response=ai_response,
+                data_found=data_found,
+                record_count=record_count,
+                filters_used=filters,
+                data_preview=data_preview,
+                conversation_history=updated_conversation_history,
+                warnings=cached.get("warnings"),
+                suggestions=cached.get("suggestions"),
+                chart=chart_spec,
+            )
+
         last_query_data = getattr(request, "_last_query_data", None)
-        filters = financial_manager.parse_user_query(
-            request.query, request.conversation_history, last_query_data
-        )
-        logger.info(f"Parsed filters: {filters}")
-        logger.info(f"filters type: {type(filters)}, filters: {filters}")
-        availability = financial_manager.validate_data_availability(filters)
-        # logger.info(f"availability type: {type(availability)}, availability: {availability}")
-        warnings = availability.get("warnings", [])
-        suggestions = availability.get("suggestions", [])
-        results = financial_manager.query_data(filters)
-        logger.info(f"results type: {type(results)}, results: {results}")
-        ai_response = financial_manager.format_response(
-            results,
-            request.query,
-            filters.interpretation,
-            filters.is_follow_up,
-            request.conversation_history,
-            unrecognized_items=filters.unrecognized_items or None,
-        )
-        # logger.info(f"ai_response type: {type(ai_response)}, ai_response: {ai_response}")
-        data_preview = results if results else None
-        updated_conversation_history = None
-        if request.memory_enabled:
-            if request.conversation_history:
-                updated_conversation_history = request.conversation_history.copy()
-            else:
-                updated_conversation_history = []
-            updated_conversation_history.append({"role": "user", "content": request.query})
-            updated_conversation_history.append({"role": "assistant", "content": ai_response})
-            if len(updated_conversation_history) > 20:
-                updated_conversation_history = updated_conversation_history[-20:]
-        # Generate chart if data is chartable
-        chart_spec = None
-        if results:
-            chart_data = generate_chart(results, request.query)
-            if chart_data:
-                chart_spec = ChartSpec(**chart_data)
-                logger.info(f"Generated {chart_data['chart_type']} chart: {chart_data['title']}")
+        request_costs = []
+        with traced_observation(
+            "fast_chat_v2", as_type="span", input={"query": request.query}
+        ) as trace_obs:
+            filters = financial_manager.parse_user_query(
+                request.query,
+                request.conversation_history,
+                last_query_data,
+                cost_sink=request_costs,
+            )
+            logger.info(f"Parsed filters: {filters}")
+            logger.info(f"filters type: {type(filters)}, filters: {filters}")
+            availability = financial_manager.validate_data_availability(filters)
+            # logger.info(f"availability type: {type(availability)}, availability: {availability}")
+            warnings = availability.get("warnings", [])
+            suggestions = availability.get("suggestions", [])
+            results = financial_manager.query_data(filters)
+            logger.info(f"results type: {type(results)}, results: {results}")
+            ai_response = financial_manager.format_response(
+                results,
+                request.query,
+                filters.interpretation,
+                filters.is_follow_up,
+                request.conversation_history,
+                unrecognized_items=filters.unrecognized_items or None,
+                cost_sink=request_costs,
+            )
+            # logger.info(f"ai_response type: {type(ai_response)}, ai_response: {ai_response}")
+            data_preview = results if results else None
+            updated_conversation_history = None
+            if request.memory_enabled:
+                if request.conversation_history:
+                    updated_conversation_history = request.conversation_history.copy()
+                else:
+                    updated_conversation_history = []
+                updated_conversation_history.append({"role": "user", "content": request.query})
+                updated_conversation_history.append({"role": "assistant", "content": ai_response})
+                if len(updated_conversation_history) > 20:
+                    updated_conversation_history = updated_conversation_history[-20:]
+            # Generate chart if data is chartable
+            chart_spec = None
+            if results:
+                chart_data = generate_chart(results, request.query)
+                if chart_data:
+                    chart_spec = ChartSpec(**chart_data)
+                    logger.info(
+                        f"Generated {chart_data['chart_type']} chart: {chart_data['title']}"
+                    )
+
+            if trace_obs is not None:
+                trace_obs.update(output=ai_response, metadata={"cache_hit": False})
 
         logger.info(
             f"/fast_chat_v2 completed. data_found={bool(results)}, record_count={len(results) if results else 0}, has_chart={chart_spec is not None}"
+        )
+
+        if cache_key and response_cache:
+            await response_cache.set(
+                cache_key,
+                {
+                    "response": ai_response,
+                    "data_found": bool(results),
+                    "record_count": len(results) if results else 0,
+                    "filters_used": filters.model_dump(),
+                    "data_preview": [r.model_dump() for r in results] if results else None,
+                    "warnings": warnings if warnings else None,
+                    "suggestions": suggestions if suggestions else None,
+                    "chart": chart_spec.model_dump() if chart_spec else None,
+                },
+            )
+
+        schedule_log(
+            response=ai_response,
+            cache_hit=False,
+            success=True,
+            data_found=bool(results),
+            record_count=len(results) if results else 0,
+            model=request_costs[0].model if request_costs else None,
+            input_tokens=sum(c.token_usage.input_tokens for c in request_costs),
+            output_tokens=sum(c.token_usage.output_tokens for c in request_costs),
+            cost_usd=sum(c.total_cost for c in request_costs),
+            phase_costs=[c.phase for c in request_costs],
         )
         return FinancialDataResponse(
             response=ai_response,
@@ -579,10 +735,12 @@ async def fast_chat_v2(
             suggestions=suggestions if suggestions else None,
             chart=chart_spec,
         )
-    except HTTPException:
+    except HTTPException as e:
+        schedule_log(response=None, cache_hit=False, success=False, error_message=str(e.detail))
         raise
     except Exception as e:
         logger.error(f"Error in fast_chat_v2 endpoint: {str(e)}")
+        schedule_log(response=None, cache_hit=False, success=False, error_message=str(e))
         raise HTTPException(
             status_code=500, detail=f"Error processing financial data query: {str(e)}"
         )
@@ -668,10 +826,25 @@ async def refresh_cache_endpoint():
 # ==============================================================================
 
 
+def _jsonable(value):
+    """Best-effort conversion of a Pydantic model (or list of them) to plain
+    dict/list for JSON caching. Passes plain dicts/None through unchanged."""
+    if value is None:
+        return None
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if isinstance(value, list):
+        return [_jsonable(v) for v in value]
+    return value
+
+
 @app.post("/chat/stream", response_model=AgentChatResponse)
 async def chat_stream(
     request: AgentChatRequest,
+    http_request: Request,
     financial_manager: Any = Depends(get_financial_manager),
+    response_cache: Any = Depends(get_response_cache_dep),
+    interaction_logger: Any = Depends(get_interaction_logger_dep),
 ):
     """
     JSE Financial Analyst endpoint using Gemini 2.5 Pro with Google Search grounding.
@@ -686,6 +859,10 @@ async def chat_stream(
     - Source citations from web search results
 
     The response is backward compatible with AgentChatResponse.
+
+    Repeated queries (same flags, no conversation history) are served from a
+    Redis response cache. Every call is logged to BigQuery for regression/
+    behavior monitoring, and traced via Langfuse if configured.
     """
     logger.info(
         f"/chat/stream called. query='{request.query[:200]}', "
@@ -701,45 +878,159 @@ async def chat_stream(
     else:
         logger.info("No conversation history received")
 
+    start_time = time.time()
+    request_id = getattr(http_request.state, "request_id", None)
+    cache_eligible = not request.conversation_history
+    cache_key = (
+        ResponseCache.build_key(
+            "chat_stream",
+            ResponseCache.normalize_query(request.query),
+            request.enable_web_search,
+            request.enable_financial_data,
+        )
+        if cache_eligible
+        else None
+    )
+
+    def schedule_log(**kwargs):
+        if interaction_logger is None:
+            return
+        row = InteractionLogger.build_row(
+            endpoint="chat_stream",
+            query=request.query,
+            request_id=request_id,
+            conversation_history=request.conversation_history,
+            memory_enabled=request.memory_enabled,
+            enable_web_search=request.enable_web_search,
+            enable_financial_data=request.enable_financial_data,
+            latency_ms=(time.time() - start_time) * 1000,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            **kwargs,
+        )
+        asyncio.create_task(interaction_logger.log(row))
+
     try:
+        cached = await response_cache.get(cache_key) if cache_key and response_cache else None
+        if cached is not None:
+            updated_conversation_history = None
+            if request.memory_enabled:
+                updated_conversation_history = [
+                    {"role": "user", "content": request.query},
+                    {"role": "assistant", "content": cached["response"]},
+                ]
+            logger.info(f"/chat/stream cache hit. data_found={cached['data_found']}")
+            schedule_log(
+                response=cached["response"],
+                cache_hit=True,
+                success=True,
+                data_found=cached["data_found"],
+                record_count=cached["record_count"],
+            )
+            return AgentChatResponse(
+                response=cached["response"],
+                data_found=cached["data_found"],
+                record_count=cached["record_count"],
+                filters_used=cached.get("filters_used"),
+                data_preview=cached.get("data_preview"),
+                conversation_history=updated_conversation_history,
+                warnings=cached.get("warnings"),
+                suggestions=cached.get("suggestions"),
+                chart=cached.get("chart"),
+                sources=cached.get("sources"),
+                web_search_results=cached.get("web_search_results"),
+                tools_executed=cached.get("tools_executed"),
+                needs_clarification=cached.get("needs_clarification", False),
+                clarification_question=cached.get("clarification_question"),
+                cost_summary=None,
+            )
+
         # Create agent with the financial manager so query_financial_data is available
         agent = AgentV2(financial_manager=financial_manager)
 
-        # Run the agent
-        result = await agent.run(
-            query=request.query,
-            conversation_history=request.conversation_history,
-            enable_web_search=request.enable_web_search,
-            enable_financial_data=request.enable_financial_data,
-        )
+        with traced_observation(
+            "chat_stream",
+            as_type="span",
+            input={
+                "query": request.query,
+                "enable_web_search": request.enable_web_search,
+                "enable_financial_data": request.enable_financial_data,
+            },
+        ) as trace_obs:
+            # Run the agent
+            result = await agent.run(
+                query=request.query,
+                conversation_history=request.conversation_history,
+                enable_web_search=request.enable_web_search,
+                enable_financial_data=request.enable_financial_data,
+            )
 
-        # Build response (compatible with AgentChatResponse)
-        response = AgentChatResponse(
-            response=result["response"],
-            data_found=result["data_found"],
-            record_count=result["record_count"],
-            filters_used=result.get("filters_used"),
-            data_preview=result.get("data_preview"),
-            conversation_history=result["conversation_history"] if request.memory_enabled else None,
-            warnings=result.get("warnings"),
-            suggestions=result.get("suggestions"),
-            chart=result.get("chart"),
-            sources=result.get("sources"),
-            web_search_results=result.get("web_search_results"),
-            tools_executed=result.get("tools_executed"),
-            needs_clarification=result.get("needs_clarification", False),
-            clarification_question=result.get("clarification_question"),
-        )
+            # Build response (compatible with AgentChatResponse)
+            response = AgentChatResponse(
+                response=result["response"],
+                data_found=result["data_found"],
+                record_count=result["record_count"],
+                filters_used=result.get("filters_used"),
+                data_preview=result.get("data_preview"),
+                conversation_history=(
+                    result["conversation_history"] if request.memory_enabled else None
+                ),
+                warnings=result.get("warnings"),
+                suggestions=result.get("suggestions"),
+                chart=result.get("chart"),
+                sources=result.get("sources"),
+                web_search_results=result.get("web_search_results"),
+                tools_executed=result.get("tools_executed"),
+                needs_clarification=result.get("needs_clarification", False),
+                clarification_question=result.get("clarification_question"),
+                cost_summary=result.get("cost_summary"),
+            )
+
+            if trace_obs is not None:
+                trace_obs.update(output=response.response, metadata={"cache_hit": False})
 
         logger.info(
             f"/chat/stream completed. response_chars={len(response.response)}, "
             f"tools_executed={response.tools_executed}"
         )
 
+        if cache_key and response_cache and not response.needs_clarification:
+            await response_cache.set(
+                cache_key,
+                {
+                    "response": response.response,
+                    "data_found": response.data_found,
+                    "record_count": response.record_count,
+                    "filters_used": _jsonable(response.filters_used),
+                    "data_preview": _jsonable(response.data_preview),
+                    "warnings": response.warnings,
+                    "suggestions": response.suggestions,
+                    "chart": _jsonable(response.chart),
+                    "sources": response.sources,
+                    "web_search_results": response.web_search_results,
+                    "tools_executed": response.tools_executed,
+                    "needs_clarification": response.needs_clarification,
+                    "clarification_question": response.clarification_question,
+                },
+            )
+
+        cost_summary = response.cost_summary
+        schedule_log(
+            response=response.response,
+            cache_hit=False,
+            success=True,
+            data_found=response.data_found,
+            record_count=response.record_count,
+            input_tokens=cost_summary.total_input_tokens if cost_summary else 0,
+            output_tokens=cost_summary.total_output_tokens if cost_summary else 0,
+            cost_usd=cost_summary.total_cost_usd if cost_summary else 0.0,
+            phase_costs=[p.phase for p in cost_summary.phases] if cost_summary else None,
+        )
+
         return response
 
     except Exception as e:
         logger.error(f"Error in chat stream endpoint: {str(e)}", exc_info=True)
+        schedule_log(response=None, cache_hit=False, success=False, error_message=str(e))
         raise HTTPException(
             status_code=500,
             detail=f"Error processing chat stream: {str(e)}",

--- a/fastapi_app/app/response_cache.py
+++ b/fastapi_app/app/response_cache.py
@@ -1,0 +1,98 @@
+"""
+Redis-backed response cache for exact/normalized-match prompt caching.
+
+Phase 1: normalized-string matching only (no semantic similarity). Caching is
+skipped entirely by callers whenever conversation history is present, since a
+follow-up's correct answer depends on context this cache doesn't key on.
+
+No-ops safely whenever Redis isn't configured or unreachable, so callers never
+need to branch on availability.
+"""
+
+import hashlib
+import json
+from typing import Any, Optional
+
+import redis.asyncio as redis
+
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class ResponseCache:
+    """Thin async wrapper around Redis for caching endpoint response payloads."""
+
+    def __init__(self, url: Optional[str], ttl_seconds: int = 3600, enabled: bool = True):
+        self._ttl = ttl_seconds
+        self._client: Optional["redis.Redis"] = None
+        self._enabled = bool(enabled and url)
+        if self._enabled:
+            try:
+                self._client = redis.from_url(
+                    url,
+                    decode_responses=True,
+                    socket_connect_timeout=2,
+                    socket_timeout=2,
+                )
+            except Exception as exc:
+                logger.warning("response_cache_init_failed", extra={"error": str(exc)})
+                self._enabled = False
+                self._client = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled and self._client is not None
+
+    @staticmethod
+    def build_key(namespace: str, *parts: Any) -> str:
+        """Build a deterministic cache key from a namespace and key parts.
+
+        Namespacing by endpoint prevents cross-endpoint collisions since
+        fast_chat_v2 and chat_stream have different response shapes.
+        """
+        normalized = "|".join(str(p) for p in parts)
+        digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+        return f"cache:v1:{namespace}:{digest}"
+
+    @staticmethod
+    def normalize_query(query: str) -> str:
+        """Lowercase + collapse whitespace. No punctuation/synonym handling (phase 1)."""
+        return " ".join(query.strip().lower().split())
+
+    async def get(self, key: str) -> Optional[dict]:
+        if not self.enabled:
+            return None
+        try:
+            raw = await self._client.get(key)
+            return json.loads(raw) if raw is not None else None
+        except Exception as exc:
+            logger.warning("response_cache_get_failed", extra={"key": key, "error": str(exc)})
+            return None
+
+    async def set(self, key: str, value: dict, ttl_seconds: Optional[int] = None) -> None:
+        if not self.enabled:
+            return
+        try:
+            await self._client.set(key, json.dumps(value, default=str), ex=ttl_seconds or self._ttl)
+        except Exception as exc:
+            logger.warning("response_cache_set_failed", extra={"key": key, "error": str(exc)})
+
+    async def close(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.close()
+            except Exception as exc:
+                logger.warning("response_cache_close_failed", extra={"error": str(exc)})
+
+
+def build_response_cache() -> ResponseCache:
+    """Construct a ResponseCache from the current app config."""
+    from app.config import get_config
+
+    cfg = get_config()
+    return ResponseCache(
+        url=cfg.redis.url,
+        ttl_seconds=cfg.redis.response_cache_ttl_seconds,
+        enabled=cfg.redis.response_cache_enabled,
+    )

--- a/fastapi_app/app/tracing.py
+++ b/fastapi_app/app/tracing.py
@@ -1,0 +1,104 @@
+"""
+Langfuse tracing for observability/cost dashboards only — not used for
+caching (Langfuse doesn't do response caching) or as the permanent
+interaction-log store (see app/interaction_log.py for that).
+
+The installed Langfuse SDK (v3+) is fully OpenTelemetry-based: there is no
+`.trace()`/`.generation()` API. Observations are created via
+`client.start_as_current_observation(...)`, which sets the new observation as
+the "current" one in OTel context for the duration of a `with` block — any
+observation started inside that block (even from a different module, deeper
+in the call stack) automatically nests under it. That means Gemini call
+sites (financial_utils.py, agent_v2.py) don't need a `trace` object threaded
+through function signatures: they just call `traced_observation(...)`
+themselves, and it nests correctly whenever called from within a request's
+outer span opened in main.py.
+
+Google GenAI has no Langfuse auto-instrumentation, so every call site wraps
+its own `generate_content(...)` call manually.
+"""
+
+from contextlib import contextmanager
+from typing import Any, Optional
+
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_client: Optional[Any] = None
+_resolved = False
+
+
+def get_langfuse_client() -> Optional[Any]:
+    """Return a singleton Langfuse client, or None if tracing isn't configured.
+
+    No-ops safely (returns None) whenever LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY
+    are unset or LANGFUSE_ENABLED=false — matches the app's default test env,
+    which sets neither, so tracing is a pure no-op in the test suite.
+    """
+    global _client, _resolved
+    if not _resolved:
+        from app.config import get_config
+
+        cfg = get_config().langfuse
+        if cfg.configured:
+            try:
+                from langfuse import Langfuse
+
+                _client = Langfuse(
+                    public_key=cfg.public_key, secret_key=cfg.secret_key, host=cfg.host
+                )
+            except Exception as exc:
+                logger.warning("langfuse_init_failed", extra={"error": str(exc)})
+                _client = None
+        _resolved = True
+    return _client
+
+
+def reset_langfuse_client() -> None:
+    """Reset the cached client. Test-only — production never needs to reconfigure."""
+    global _client, _resolved
+    _client = None
+    _resolved = False
+
+
+def log_completed_generation(
+    name: str,
+    model: Optional[str] = None,
+    input: Optional[Any] = None,
+    output: Optional[Any] = None,
+    usage_details: Optional[dict] = None,
+) -> None:
+    """Log a generation that has already completed (e.g. from a cost-tracking
+    choke point that only sees the response after the call). Unlike
+    `traced_observation`, there's no `with` block to wrap around a call that
+    already happened — this creates, updates, and ends the observation in one
+    shot. No-ops when tracing isn't configured.
+    """
+    client = get_langfuse_client()
+    if client is None:
+        return
+    try:
+        obs = client.start_observation(name=name, as_type="generation", model=model, input=input)
+        obs.update(output=output, usage_details=usage_details)
+        obs.end()
+    except Exception as exc:
+        logger.warning("langfuse_log_generation_failed", extra={"name": name, "error": str(exc)})
+
+
+@contextmanager
+def traced_observation(name: str, as_type: str = "span", **kwargs: Any):
+    """Context manager yielding a Langfuse observation, or None when tracing
+    is unconfigured. Callers must guard `.update(...)` calls on `is not None`.
+    """
+    client = get_langfuse_client()
+    if client is None:
+        yield None
+        return
+    try:
+        with client.start_as_current_observation(name=name, as_type=as_type, **kwargs) as obs:
+            yield obs
+    except Exception as exc:
+        # Tracing must never break the request it's observing.
+        logger.warning("langfuse_observation_failed", extra={"name": name, "error": str(exc)})
+        yield None

--- a/fastapi_app/copilot/examples/api/manifest.yml.example
+++ b/fastapi_app/copilot/examples/api/manifest.yml.example
@@ -88,6 +88,20 @@ variables:
   ASYNC_JOB_TTL_SECONDS: "900"  # 15 minutes - jobs expire after this time
   ASYNC_JOB_MAX_PROGRESS_HISTORY: "50"  # Keep last 50 progress updates
 
+  # Response cache (Redis, via the ElastiCache addon in api/addons/redis.yml)
+  RESPONSE_CACHE_ENABLED: "true"
+  RESPONSE_CACHE_TTL_SECONDS: "3600"  # 1 hour
+
+  # Permanent interaction logging (BigQuery) - table must already exist,
+  # see scripts/create_interactions_table.py
+  INTERACTION_LOGGING_ENABLED: "true"
+  BIGQUERY_INTERACTIONS_TABLE: "interactions"
+  # BIGQUERY_INTERACTIONS_DATASET: <YOUR_BIGQUERY_DATASET>  # defaults to BIGQUERY_DATASET if unset
+
+  # Langfuse tracing/dashboards (Langfuse Cloud Hobby tier or self-hosted)
+  LANGFUSE_ENABLED: "true"
+  LANGFUSE_HOST: "https://cloud.langfuse.com"
+
 # RECOMMENDED: Move secrets to AWS Secrets Manager for better security
 # Uncomment and configure the secrets section below, then remove sensitive variables above
 secrets:
@@ -97,6 +111,8 @@ secrets:
   # AWS_ACCESS_KEY_ID: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AWS_ACCESS_KEY_ID
   # AWS_SECRET_ACCESS_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AWS_SECRET_ACCESS_KEY
   # GCP_SERVICE_ACCOUNT_INFO: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/GCP_SERVICE_ACCOUNT_INFO
+  # LANGFUSE_PUBLIC_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/LANGFUSE_PUBLIC_KEY
+  # LANGFUSE_SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/LANGFUSE_SECRET_KEY
 
 # You can override any of the values defined above by environment.
 environments:

--- a/fastapi_app/pyproject.toml
+++ b/fastapi_app/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "requests>=2.31.0",
     "openpyxl==3.1.2",
     "prometheus-client>=0.19.0",
+    "langfuse>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/fastapi_app/requirements.txt
+++ b/fastapi_app/requirements.txt
@@ -42,6 +42,7 @@ requests>=2.31.0
 redis>=4.2.0
 structlog>=24.1.0
 prometheus-client>=0.19.0
+langfuse>=3.0.0
 
 # Pin compatible versions to avoid conflicts
 grpcio>=1.60.0,<2.0.0

--- a/fastapi_app/tests/test_api_integration.py
+++ b/fastapi_app/tests/test_api_integration.py
@@ -185,6 +185,10 @@ class MockBQClient:
         # Default: return empty result set for any unrecognized query
         return MockQueryResult([])
 
+    def insert_rows_json(self, table, rows, **kwargs):
+        # BigQuery convention: empty list = success, no row-level errors.
+        return []
+
 
 @pytest.fixture(autouse=True)
 def patch_bq_client(monkeypatch):

--- a/fastapi_app/tests/unit/test_interaction_log.py
+++ b/fastapi_app/tests/unit/test_interaction_log.py
@@ -1,0 +1,88 @@
+"""Unit tests for InteractionLogger."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.interaction_log import InteractionLogger, build_interaction_logger
+
+
+def test_disabled_when_no_client():
+    logger_ = InteractionLogger(bq_client=None, dataset="ds", table="interactions", enabled=True)
+    assert logger_.enabled is False
+
+
+def test_disabled_when_flag_off():
+    client = MagicMock()
+    logger_ = InteractionLogger(bq_client=client, dataset="ds", table="interactions", enabled=False)
+    assert logger_.enabled is False
+
+
+def test_disabled_when_dataset_missing():
+    client = MagicMock()
+    logger_ = InteractionLogger(bq_client=client, dataset=None, table="interactions", enabled=True)
+    assert logger_.enabled is False
+
+
+def test_build_row_shape():
+    row = InteractionLogger.build_row(
+        endpoint="fast_chat_v2",
+        query="revenue for nyc holdings",
+        response="Here is the revenue.",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=0.001,
+        cache_hit=False,
+        success=True,
+        timestamp="2026-08-14T00:00:00Z",
+    )
+    assert row["endpoint"] == "fast_chat_v2"
+    assert row["total_tokens"] == 150
+    assert row["cache_hit"] is False
+    assert row["success"] is True
+    assert "interaction_id" in row and row["interaction_id"]
+
+
+@pytest.mark.asyncio
+async def test_log_noop_when_disabled():
+    logger_ = InteractionLogger(bq_client=None, dataset="ds", table="interactions", enabled=True)
+    await logger_.log({"query": "x"})  # must not raise, must not touch a client
+
+
+@pytest.mark.asyncio
+async def test_log_calls_insert_rows_json():
+    client = MagicMock()
+    client.insert_rows_json.return_value = []
+    logger_ = InteractionLogger(bq_client=client, dataset="ds", table="interactions", enabled=True)
+    await logger_.log({"query": "x"})
+    client.insert_rows_json.assert_called_once()
+    args, _ = client.insert_rows_json.call_args
+    assert args[0] == "ds.interactions"
+    assert args[1] == [{"query": "x"}]
+
+
+@pytest.mark.asyncio
+async def test_log_swallows_insert_errors():
+    client = MagicMock()
+    client.insert_rows_json.side_effect = Exception("insert failed")
+    logger_ = InteractionLogger(bq_client=client, dataset="ds", table="interactions", enabled=True)
+    await logger_.log({"query": "x"})  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_log_reports_row_level_errors_without_raising():
+    client = MagicMock()
+    client.insert_rows_json.return_value = [{"index": 0, "errors": ["bad row"]}]
+    logger_ = InteractionLogger(bq_client=client, dataset="ds", table="interactions", enabled=True)
+    await logger_.log({"query": "x"})  # must not raise
+
+
+def test_build_interaction_logger_disabled_when_logging_disabled():
+    mock_config = MagicMock()
+    mock_config.bigquery.logging_enabled = False
+    mock_config.bigquery.resolved_interactions_dataset = "ds"
+    mock_config.bigquery.interactions_table = "interactions"
+    mock_config.gcp.project_id = "proj"
+    with patch("app.config.get_config", return_value=mock_config):
+        logger_ = build_interaction_logger()
+    assert logger_.enabled is False

--- a/fastapi_app/tests/unit/test_response_cache.py
+++ b/fastapi_app/tests/unit/test_response_cache.py
@@ -1,0 +1,96 @@
+"""Unit tests for ResponseCache."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.response_cache import ResponseCache, build_response_cache
+
+
+def test_disabled_when_url_missing():
+    cache = ResponseCache(url=None, ttl_seconds=60, enabled=True)
+    assert cache.enabled is False
+
+
+def test_disabled_when_flag_off():
+    cache = ResponseCache(url="redis://localhost:6379/0", ttl_seconds=60, enabled=False)
+    assert cache.enabled is False
+
+
+def test_disabled_on_construction_failure():
+    with patch("app.response_cache.redis.from_url", side_effect=Exception("boom")):
+        cache = ResponseCache(url="redis://localhost:6379/0", ttl_seconds=60, enabled=True)
+    assert cache.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_get_set_noop_when_disabled():
+    cache = ResponseCache(url=None, ttl_seconds=60, enabled=True)
+    await cache.set("key", {"a": 1})
+    assert await cache.get("key") is None
+
+
+def test_build_key_deterministic():
+    k1 = ResponseCache.build_key("fast_chat_v2", "revenue for nyc holdings")
+    k2 = ResponseCache.build_key("fast_chat_v2", "revenue for nyc holdings")
+    assert k1 == k2
+
+
+def test_build_key_differs_by_namespace_and_parts():
+    base = ResponseCache.build_key("fast_chat_v2", "same query")
+    other_ns = ResponseCache.build_key("chat_stream", "same query")
+    other_parts = ResponseCache.build_key("fast_chat_v2", "same query", True)
+    assert base != other_ns
+    assert base != other_parts
+
+
+def test_normalize_query_collapses_whitespace_and_case():
+    assert (
+        ResponseCache.normalize_query("  Revenue   For   NYC Holdings  ")
+        == "revenue for nyc holdings"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_set_roundtrip_with_mocked_client():
+    with patch("app.response_cache.redis.from_url") as mock_from_url:
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=None)
+        mock_client.set = AsyncMock()
+        mock_from_url.return_value = mock_client
+
+        cache = ResponseCache(url="redis://localhost:6379/0", ttl_seconds=60, enabled=True)
+        assert cache.enabled is True
+
+        await cache.set("key", {"response": "hi"})
+        mock_client.set.assert_called_once()
+        args, kwargs = mock_client.set.call_args
+        assert args[0] == "key"
+        assert kwargs["ex"] == 60
+
+        mock_client.get = AsyncMock(return_value='{"response": "hi"}')
+        result = await cache.get("key")
+        assert result == {"response": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_get_set_swallow_client_errors():
+    with patch("app.response_cache.redis.from_url") as mock_from_url:
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=Exception("connection lost"))
+        mock_client.set = AsyncMock(side_effect=Exception("connection lost"))
+        mock_from_url.return_value = mock_client
+
+        cache = ResponseCache(url="redis://localhost:6379/0", ttl_seconds=60, enabled=True)
+        assert await cache.get("key") is None
+        await cache.set("key", {"a": 1})  # must not raise
+
+
+def test_build_response_cache_uses_config(monkeypatch):
+    mock_config = MagicMock()
+    mock_config.redis.url = None
+    mock_config.redis.response_cache_ttl_seconds = 3600
+    mock_config.redis.response_cache_enabled = True
+    with patch("app.config.get_config", return_value=mock_config):
+        cache = build_response_cache()
+    assert cache.enabled is False

--- a/fastapi_app/tests/unit/test_tracing.py
+++ b/fastapi_app/tests/unit/test_tracing.py
@@ -1,0 +1,132 @@
+"""Unit tests for the Langfuse tracing module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.tracing as tracing
+
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    tracing.reset_langfuse_client()
+    yield
+    tracing.reset_langfuse_client()
+
+
+def test_get_langfuse_client_none_when_unconfigured():
+    mock_config = MagicMock()
+    mock_config.langfuse.configured = False
+    with patch("app.config.get_config", return_value=mock_config):
+        assert tracing.get_langfuse_client() is None
+
+
+def test_get_langfuse_client_returns_client_when_configured():
+    mock_config = MagicMock()
+    mock_config.langfuse.configured = True
+    mock_config.langfuse.public_key = "pub"
+    mock_config.langfuse.secret_key = "sec"
+    mock_config.langfuse.host = "https://cloud.langfuse.com"
+
+    mock_instance = MagicMock()
+    with patch("app.config.get_config", return_value=mock_config):
+        with patch("langfuse.Langfuse", return_value=mock_instance) as mock_ctor:
+            client = tracing.get_langfuse_client()
+    assert client is mock_instance
+    mock_ctor.assert_called_once_with(
+        public_key="pub", secret_key="sec", host="https://cloud.langfuse.com"
+    )
+
+
+def test_get_langfuse_client_is_cached():
+    mock_config = MagicMock()
+    mock_config.langfuse.configured = True
+    mock_config.langfuse.public_key = "pub"
+    mock_config.langfuse.secret_key = "sec"
+    mock_config.langfuse.host = "https://cloud.langfuse.com"
+
+    with patch("app.config.get_config", return_value=mock_config):
+        with patch("langfuse.Langfuse", return_value=MagicMock()) as mock_ctor:
+            tracing.get_langfuse_client()
+            tracing.get_langfuse_client()
+    assert mock_ctor.call_count == 1
+
+
+def test_get_langfuse_client_none_on_init_failure():
+    mock_config = MagicMock()
+    mock_config.langfuse.configured = True
+    mock_config.langfuse.public_key = "pub"
+    mock_config.langfuse.secret_key = "sec"
+    mock_config.langfuse.host = "https://cloud.langfuse.com"
+
+    with patch("app.config.get_config", return_value=mock_config):
+        with patch("langfuse.Langfuse", side_effect=Exception("boom")):
+            assert tracing.get_langfuse_client() is None
+
+
+def test_traced_observation_yields_none_when_unconfigured():
+    with patch("app.tracing.get_langfuse_client", return_value=None):
+        with tracing.traced_observation("test-span") as obs:
+            assert obs is None
+
+
+def test_traced_observation_yields_observation_when_configured():
+    mock_obs = MagicMock()
+    mock_client = MagicMock()
+    mock_client.start_as_current_observation.return_value.__enter__.return_value = mock_obs
+    mock_client.start_as_current_observation.return_value.__exit__.return_value = False
+
+    with patch("app.tracing.get_langfuse_client", return_value=mock_client):
+        with tracing.traced_observation(
+            "test-span", as_type="generation", model="gemini-2.5-flash"
+        ) as obs:
+            assert obs is mock_obs
+
+    mock_client.start_as_current_observation.assert_called_once_with(
+        name="test-span", as_type="generation", model="gemini-2.5-flash"
+    )
+
+
+def test_traced_observation_swallows_client_errors():
+    mock_client = MagicMock()
+    mock_client.start_as_current_observation.side_effect = Exception("boom")
+
+    with patch("app.tracing.get_langfuse_client", return_value=mock_client):
+        with tracing.traced_observation("test-span") as obs:
+            assert obs is None
+
+
+def test_log_completed_generation_noop_when_unconfigured():
+    with patch("app.tracing.get_langfuse_client", return_value=None):
+        tracing.log_completed_generation("phase", model="gemini-2.5-flash")  # must not raise
+
+
+def test_log_completed_generation_creates_updates_and_ends():
+    mock_obs = MagicMock()
+    mock_client = MagicMock()
+    mock_client.start_observation.return_value = mock_obs
+
+    with patch("app.tracing.get_langfuse_client", return_value=mock_client):
+        tracing.log_completed_generation(
+            "phase",
+            model="gemini-2.5-flash",
+            input="prompt",
+            output="answer",
+            usage_details={"input": 10, "output": 5},
+        )
+
+    mock_client.start_observation.assert_called_once_with(
+        name="phase", as_type="generation", model="gemini-2.5-flash", input="prompt"
+    )
+    mock_obs.update.assert_called_once_with(
+        output="answer", usage_details={"input": 10, "output": 5}
+    )
+    mock_obs.end.assert_called_once()
+
+
+def test_log_completed_generation_swallows_client_errors():
+    mock_client = MagicMock()
+    mock_client.start_observation.side_effect = Exception("boom")
+
+    with patch("app.tracing.get_langfuse_client", return_value=mock_client):
+        tracing.log_completed_generation("phase")  # must not raise

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ Utility scripts for development, testing, and maintenance.
 - **run_metadata_rebuild.py** - Runner script for metadata rebuild
 - **find_unmapped_codes.py** - Identifies unmapped company codes
 - **push_copilot_secrets.py** - Pushes `.env` values to AWS SSM for the Copilot deploy
+- **create_interactions_table.py** - One-time (idempotent) creation of the BigQuery `interactions` table used for permanent interaction logging (see `docs/CACHING_LOGGING_TRACING.md`)
 
 See `archive/` for manual test clients that targeted endpoints removed in the
 2026-08-14 prod-cleanup pass (`/chroma/*`, `/chat/stream/v0`'s async-job polling).

--- a/scripts/create_interactions_table.py
+++ b/scripts/create_interactions_table.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+One-time (idempotent) creation of the BigQuery `interactions` table used for
+permanent interaction logging by fastapi_app/app/interaction_log.py.
+
+Requires real GCP credentials (GOOGLE_APPLICATION_CREDENTIALS or ADC) — run
+this once per environment/dataset before deploying interaction logging.
+"""
+
+import argparse
+import sys
+
+from google.api_core.exceptions import NotFound
+from google.cloud import bigquery
+
+sys.path.insert(0, "fastapi_app")
+from app.interaction_log import INTERACTIONS_SCHEMA  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create the BigQuery `interactions` table if it doesn't already exist."
+    )
+    parser.add_argument("--project", required=True, help="GCP project ID")
+    parser.add_argument("--dataset", required=True, help="BigQuery dataset name")
+    parser.add_argument("--table", default="interactions", help="Table name. Default: interactions")
+    parser.add_argument("--location", default="US", help="BigQuery location. Default: US")
+
+    args = parser.parse_args()
+
+    client = bigquery.Client(project=args.project, location=args.location)
+    table_ref = f"{args.project}.{args.dataset}.{args.table}"
+
+    try:
+        client.get_table(table_ref)
+        print(f"Table '{table_ref}' already exists. Nothing to do.")
+        return
+    except NotFound:
+        pass
+
+    table = bigquery.Table(table_ref, schema=INTERACTIONS_SCHEMA)
+    client.create_table(table)
+    print(f"Created table '{table_ref}'.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/push_copilot_secrets.py
+++ b/scripts/push_copilot_secrets.py
@@ -59,6 +59,8 @@ def main():
         "AWS_SECRET_ACCESS_KEY",
         "GOOGLE_API_KEY",
         "GCP_SERVICE_ACCOUNT_INFO",
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
     ]
 
     pushed_count = 0


### PR DESCRIPTION
## Summary

Adds three cross-cutting pieces to the two production endpoints, `POST /fast_chat_v2` and `POST /chat/stream` (`/chat` is untouched):

- **Redis response cache** (`app/response_cache.py`) — normalized exact-match caching (phase 1, no semantic similarity yet) to skip the Gemini call on repeated prompts. Skipped whenever `conversation_history` is present, since a follow-up's correct answer depends on that context; `chat_stream`'s cache key also includes `enable_web_search`/`enable_financial_data`. No-ops safely when Redis isn't configured — reuses the existing (previously unused) `RedisConfig`/ElastiCache Copilot addon.
- **Permanent BigQuery interaction logging** (`app/interaction_log.py`) — every call (success and failure) is logged with query, response, tokens, cost, latency, and cache hit/miss, for regression/behavior monitoring. Chosen over relying on Langfuse's own (time-limited, 30-day on the free tier) trace retention. Fires via `asyncio.create_task(...)` so a logging failure never affects the user-facing request or its latency. Includes a one-time idempotent table-creation script (`scripts/create_interactions_table.py`).
- **Langfuse tracing** (`app/tracing.py`) — trace-level observability/cost dashboards only, not caching and not the permanent log. No-ops safely when `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` are unset.

Also fixes two gaps this work depends on:
- `financial_utils.py`'s two Gemini call sites (`parse_user_query`, `format_response`) never extracted token usage — they now do, feeding both interaction logging and Langfuse.
- `chat_stream` computed a `cost_summary` via `AgentV2.run()` but never passed it into the `AgentChatResponse` it returned — it's now wired through.

New env vars, config, and deploy runbook are documented in `docs/CACHING_LOGGING_TRACING.md` and `fastapi_app/.env.example`.

## Test plan

- [x] `pytest tests/unit tests/integration/test_api_endpoints.py tests/test_agent_v2_financial.py tests/test_api.py tests/test_chat_stream_financial.py` — 119 passed (29 new tests for the three new modules)
- [x] Confirmed no regressions vs. the pre-change baseline on the full suite (`36 failed, 158 passed, 14 errors` identical before/after — all pre-existing failures trace to an unrelated `google-auth` version mismatch in this sandbox, not this change)
- [x] `black`/`ruff` clean on all changed/new files
- [ ] Manual smoke test against a real Redis/BigQuery/Langfuse (requires deploying — see `docs/CACHING_LOGGING_TRACING.md` for the exact commands a human needs to run: table creation, secret push, Copilot deploy)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZWV8AoEr8f2NuCqqqHWvL)_