### PR TITLE
fix: ground /chat/stream ticker identity against verified JSE metadata

### DIFF
--- a/fastapi_app/app/agent_v2.py
+++ b/fastapi_app/app/agent_v2.py
@@ -12,10 +12,12 @@ Architecture:
 - Compatible with AgentChatRequest/AgentChatResponse contract
 """
 
+import asyncio
 from typing import Any, Dict, List, Optional
 
 from google.genai import types
 
+from app.document_selector import extract_companies_from_query
 from app.gemini_client import get_genai_client
 from app.logging_config import get_logger
 from app.models import CostSummary, PhaseCost
@@ -325,6 +327,74 @@ class AgentV2:
         return {"sources": sources, "search_results": search_results}
 
     # --------------------------------------------------------------------------
+    # Ticker/Company Grounding (AEO-25 — prevents ticker-identity hallucination)
+    # --------------------------------------------------------------------------
+
+    async def _extract_grounded_symbols(
+        self,
+        query: str,
+        conversation_history: Optional[List[Dict[str, str]]],
+        financial_manager: Any,
+    ) -> List[str]:
+        """Identify JSE ticker symbols the query is clearly asking about.
+
+        Reuses the same Stage-1 extraction already used for /chat's document
+        auto-loading (app.document_selector.extract_companies_from_query) —
+        an LLM call that understands context, so it doesn't mistake a metric
+        abbreviation (e.g. "ROC" meaning Return on Capital) for a ticker
+        mention. Runs in a thread so it can overlap with the router call.
+        """
+        if financial_manager is None or not getattr(financial_manager, "metadata", None):
+            return []
+        metadata = financial_manager.metadata
+        companies = metadata.get("companies") or []
+        symbols = metadata.get("symbols") or []
+        if not symbols:
+            return []
+        extracted = await asyncio.to_thread(
+            extract_companies_from_query, query, companies, symbols, conversation_history
+        )
+        return extracted.get("symbols") or []
+
+    def _build_grounding_note(
+        self, extracted_symbols: List[str], financial_manager: Any
+    ) -> Optional[str]:
+        """Build a verified ticker->company fact block from real JSE metadata
+        (Stage 2 — deterministic lookup, no LLM involved) for any symbols the
+        extraction step surfaced. Returns None if nothing resolves."""
+        if not extracted_symbols or financial_manager is None:
+            return None
+        metadata = getattr(financial_manager, "metadata", None) or {}
+        symbol_to_company = metadata.get("associations", {}).get("symbol_to_company", {})
+        if not symbol_to_company:
+            return None
+
+        lookup = {k.upper(): (k, v) for k, v in symbol_to_company.items() if k}
+        lines = []
+        seen = set()
+        for sym in extracted_symbols:
+            match = lookup.get(str(sym).strip().upper())
+            if not match:
+                continue
+            real_symbol, companies = match
+            if real_symbol in seen:
+                continue
+            verified_companies = sorted({c for c in companies if c})
+            if not verified_companies:
+                continue
+            seen.add(real_symbol)
+            lines.append(f"- {real_symbol} = {' / '.join(verified_companies)}")
+
+        if not lines:
+            return None
+        return (
+            "[VERIFIED JSE DATA — ground truth from official JSE records. Use this "
+            "for company/ticker identity. Do not describe a ticker symbol as shared "
+            "or ambiguous unless multiple companies are listed for it below.]\n"
+            + "\n".join(lines)
+        )
+
+    # --------------------------------------------------------------------------
     # Main Entry Point
     # --------------------------------------------------------------------------
 
@@ -413,6 +483,7 @@ class AgentV2:
         query: str,
         conversation_history: Optional[List[Dict[str, str]]] = None,
         enable_web_search: bool = True,
+        financial_manager: Any = None,
     ) -> Dict[str, Any]:
         """
         Run the agent, optionally with Google Search grounding.
@@ -422,6 +493,10 @@ class AgentV2:
             conversation_history: Previous conversation messages
             enable_web_search: When False, omits the GoogleSearch tool and removes
                 the web-search instruction from the system prompt.
+            financial_manager: Optional FinancialDataManager whose verified
+                symbol/company metadata is used to ground ticker-identity claims
+                (e.g. "MDS") against real JSE records. No BigQuery data query
+                happens here — only a lookup against already-loaded metadata.
 
         Returns:
             Dictionary compatible with AgentChatResponse
@@ -430,10 +505,18 @@ class AgentV2:
 
         self._reset_cost_tracking()
 
+        # Kick off symbol extraction now so its network call overlaps with the
+        # router call below instead of adding to total latency.
+        symbol_task = asyncio.create_task(
+            self._extract_grounded_symbols(query, conversation_history, financial_manager)
+        )
+
         # Fast path: Flash router. Returns a result on REFUSE; returns None to
         # fall through to the Pro+grounding path for every other query.
         fast_result = await self._fast_path(query, conversation_history)
         if fast_result is not None:
+            if not symbol_task.done():
+                symbol_task.cancel()
             logger.info(
                 f"AgentV2 fast_path used. " f"record_count={fast_result.get('record_count', 0)}"
             )
@@ -442,6 +525,15 @@ class AgentV2:
         try:
             # Build conversation contents
             contents = self._build_contents(conversation_history, query)
+
+            extracted_symbols = await symbol_task
+            grounding_note = self._build_grounding_note(extracted_symbols, financial_manager)
+            if grounding_note:
+                last = contents[-1]
+                contents[-1] = types.Content(
+                    role=last.role,
+                    parts=[types.Part.from_text(text=grounding_note)] + list(last.parts),
+                )
 
             tools = [types.Tool(google_search=types.GoogleSearch())] if enable_web_search else None
             system_prompt = SYSTEM_PROMPT if enable_web_search else SYSTEM_PROMPT_NO_SEARCH

--- a/fastapi_app/app/agent_v2.py
+++ b/fastapi_app/app/agent_v2.py
@@ -390,8 +390,7 @@ class AgentV2:
         return (
             "[VERIFIED JSE DATA — ground truth from official JSE records. Use this "
             "for company/ticker identity. Do not describe a ticker symbol as shared "
-            "or ambiguous unless multiple companies are listed for it below.]\n"
-            + "\n".join(lines)
+            "or ambiguous unless multiple companies are listed for it below.]\n" + "\n".join(lines)
         )
 
     # --------------------------------------------------------------------------

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -844,6 +844,7 @@ async def chat_stream(
     http_request: Request,
     response_cache: Any = Depends(get_response_cache_dep),
     interaction_logger: Any = Depends(get_interaction_logger_dep),
+    financial_manager: Any = Depends(get_financial_manager),
 ):
     """
     JSE Financial Analyst endpoint using Gemini 2.5 Pro with Google Search grounding.
@@ -958,6 +959,7 @@ async def chat_stream(
                 query=request.query,
                 conversation_history=request.conversation_history,
                 enable_web_search=request.enable_web_search,
+                financial_manager=financial_manager,
             )
 
             # Build response (compatible with AgentChatResponse)

--- a/fastapi_app/tests/test_agent_v2_grounding.py
+++ b/fastapi_app/tests/test_agent_v2_grounding.py
@@ -1,0 +1,219 @@
+"""Tests for AgentV2's ticker/company grounding-note injection (AEO-25).
+
+/chat/stream answers purely from Gemini 2.5 Pro + Google Search grounding
+with no BigQuery data-query backstop (see test_agent_v2_router.py). That
+architecture has no defense against the model misremembering which company a
+JSE ticker symbol belongs to — verified in prod: asking about "MDS" produced
+a fabricated claim that the ticker is shared between Medical Disposables &
+Supplies Limited and Mailpac Group Limited (whose real symbol is MAILPAC).
+
+The fix reuses the existing two-stage disambiguation pattern from
+app.document_selector (already used by /chat's document auto-loading):
+Stage 1 is an LLM call that extracts ticker symbols the query is clearly
+asking about (so it doesn't mistake a metric abbreviation like "ROC" for a
+ticker mention), Stage 2 is a deterministic lookup against the real
+symbol_to_company associations already loaded from BigQuery. If a symbol
+resolves, a verified fact block is injected into the Pro call's contents.
+No BigQuery query happens per-request — only a dict lookup against metadata
+that was already loaded at startup.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.agent_v2 import AgentV2
+
+
+@pytest.fixture
+def mock_genai_client():
+    with patch("app.agent_v2.get_genai_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        yield mock_client
+
+
+def _route_response(decision="ALLOW"):
+    resp = MagicMock()
+    resp.text = decision
+    resp.candidates = []
+    resp.usage_metadata = None
+    return resp
+
+
+def _text_response(text):
+    resp = MagicMock()
+    resp.text = text
+    resp.candidates = []
+    resp.usage_metadata = None
+    return resp
+
+
+def _financial_manager(symbol_to_company):
+    fm = MagicMock()
+    fm.metadata = {
+        "companies": sorted({c for cs in symbol_to_company.values() for c in cs if c}),
+        "symbols": sorted(symbol_to_company.keys()),
+        "associations": {"symbol_to_company": symbol_to_company},
+    }
+    return fm
+
+
+# ---------------------------------------------------------------------------
+# _build_grounding_note — pure Stage-2 lookup, no mocking needed
+# ---------------------------------------------------------------------------
+
+
+def test_grounding_note_none_when_no_symbols_extracted():
+    agent = AgentV2()
+    fm = _financial_manager({"MDS": ["Medical Disposables & Supplies Limited"]})
+    assert agent._build_grounding_note([], fm) is None
+
+
+def test_grounding_note_none_when_no_financial_manager():
+    agent = AgentV2()
+    assert agent._build_grounding_note(["MDS"], None) is None
+
+
+def test_grounding_note_none_when_symbol_not_in_associations():
+    agent = AgentV2()
+    fm = _financial_manager({"MDS": ["Medical Disposables & Supplies Limited"]})
+    assert agent._build_grounding_note(["NOTREAL"], fm) is None
+
+
+def test_grounding_note_resolves_verified_company():
+    agent = AgentV2()
+    fm = _financial_manager(
+        {
+            "MDS": ["Medical Disposables & Supplies Limited"],
+            "MAILPAC": ["Mailpac Group Limited"],
+        }
+    )
+    note = agent._build_grounding_note(["MDS"], fm)
+    assert note is not None
+    assert "MDS = Medical Disposables & Supplies Limited" in note
+    # Must not pull in the distinct MAILPAC company just because both are known.
+    assert "Mailpac" not in note
+
+
+def test_grounding_note_is_case_insensitive():
+    agent = AgentV2()
+    fm = _financial_manager({"MDS": ["Medical Disposables & Supplies Limited"]})
+    note = agent._build_grounding_note(["mds"], fm)
+    assert note is not None
+    assert "MDS = Medical Disposables & Supplies Limited" in note
+
+
+def test_grounding_note_filters_empty_string_company_artifacts():
+    """BigQuery ARRAY_AGG with NULL Company rows can leave '' in the list;
+    those aren't real companies and must never surface as a fact."""
+    agent = AgentV2()
+    fm = _financial_manager({"GK": ["", "Gracekennedy Limited"]})
+    note = agent._build_grounding_note(["GK"], fm)
+    assert note == "\n".join(
+        [
+            "[VERIFIED JSE DATA — ground truth from official JSE records. Use this "
+            "for company/ticker identity. Do not describe a ticker symbol as shared "
+            "or ambiguous unless multiple companies are listed for it below.]",
+            "- GK = Gracekennedy Limited",
+        ]
+    )
+
+
+def test_grounding_note_lists_multiple_companies_if_genuinely_shared():
+    agent = AgentV2()
+    fm = _financial_manager({"XYZ": ["Company A Limited", "Company B Limited"]})
+    note = agent._build_grounding_note(["XYZ"], fm)
+    assert "Company A Limited / Company B Limited" in note
+
+
+# ---------------------------------------------------------------------------
+# run() — end-to-end wiring: extraction -> lookup -> injected into contents
+# ---------------------------------------------------------------------------
+
+
+def test_run_injects_grounding_note_into_pro_call(mock_genai_client):
+    mock_genai_client.models.generate_content.side_effect = [
+        _route_response("ALLOW"),
+        _text_response("Medical Disposables & Supplies reported J$3.88 billion."),
+    ]
+    fm = _financial_manager(
+        {
+            "MDS": ["Medical Disposables & Supplies Limited"],
+            "MAILPAC": ["Mailpac Group Limited"],
+        }
+    )
+    with patch("app.agent_v2.extract_companies_from_query") as mock_extract:
+        mock_extract.return_value = {
+            "companies": ["Medical Disposables & Supplies Limited"],
+            "symbols": ["MDS"],
+        }
+        agent = AgentV2()
+        result = asyncio.run(
+            agent.run(query="What was the revenue for MDS in 2025", financial_manager=fm)
+        )
+
+    assert result["response"] == "Medical Disposables & Supplies reported J$3.88 billion."
+    calls = mock_genai_client.models.generate_content.call_args_list
+    assert len(calls) == 2
+    pro_contents = calls[1].kwargs["contents"]
+    last_turn_parts = pro_contents[-1].parts
+    assert len(last_turn_parts) == 2
+    assert "MDS = Medical Disposables & Supplies Limited" in last_turn_parts[0].text
+    assert last_turn_parts[1].text == "What was the revenue for MDS in 2025"
+
+
+def test_run_no_grounding_note_without_financial_manager(mock_genai_client):
+    mock_genai_client.models.generate_content.side_effect = [
+        _route_response("ALLOW"),
+        _text_response("answer"),
+    ]
+    with patch("app.agent_v2.extract_companies_from_query") as mock_extract:
+        agent = AgentV2()
+        asyncio.run(agent.run(query="What was NCB revenue in 2023?"))
+        mock_extract.assert_not_called()
+
+    calls = mock_genai_client.models.generate_content.call_args_list
+    pro_contents = calls[1].kwargs["contents"]
+    assert len(pro_contents[-1].parts) == 1
+    assert pro_contents[-1].parts[0].text == "What was NCB revenue in 2023?"
+
+
+def test_run_no_grounding_note_when_extraction_finds_nothing(mock_genai_client):
+    mock_genai_client.models.generate_content.side_effect = [
+        _route_response("ALLOW"),
+        _text_response("answer"),
+    ]
+    fm = _financial_manager({"MDS": ["Medical Disposables & Supplies Limited"]})
+    with patch("app.agent_v2.extract_companies_from_query") as mock_extract:
+        mock_extract.return_value = {"companies": [], "symbols": []}
+        agent = AgentV2()
+        asyncio.run(agent.run(query="How is the Jamaican economy doing?", financial_manager=fm))
+
+    calls = mock_genai_client.models.generate_content.call_args_list
+    pro_contents = calls[1].kwargs["contents"]
+    assert len(pro_contents[-1].parts) == 1
+
+
+def test_run_refuse_path_unaffected_by_grounding(mock_genai_client):
+    """REFUSE still short-circuits to 2 Flash calls; extraction (if it ever
+    resolves) must not force an extra Pro call or change the refusal text."""
+    mock_genai_client.models.generate_content.side_effect = [
+        _route_response("REFUSE"),
+        _text_response("Sorry, I can only help with JSE topics."),
+    ]
+    fm = _financial_manager({"MDS": ["Medical Disposables & Supplies Limited"]})
+    with patch("app.agent_v2.extract_companies_from_query") as mock_extract:
+        mock_extract.return_value = {
+            "companies": ["Medical Disposables & Supplies Limited"],
+            "symbols": ["MDS"],
+        }
+        agent = AgentV2()
+        result = asyncio.run(
+            agent.run(query="Write me a poem about MDS.", financial_manager=fm)
+        )
+
+    assert result["response"] == "Sorry, I can only help with JSE topics."
+    calls = mock_genai_client.models.generate_content.call_args_list
+    assert len(calls) == 2

--- a/fastapi_app/tests/test_agent_v2_grounding.py
+++ b/fastapi_app/tests/test_agent_v2_grounding.py
@@ -210,9 +210,7 @@ def test_run_refuse_path_unaffected_by_grounding(mock_genai_client):
             "symbols": ["MDS"],
         }
         agent = AgentV2()
-        result = asyncio.run(
-            agent.run(query="Write me a poem about MDS.", financial_manager=fm)
-        )
+        result = asyncio.run(agent.run(query="Write me a poem about MDS.", financial_manager=fm))
 
     assert result["response"] == "Sorry, I can only help with JSE topics."
     calls = mock_genai_client.models.generate_content.call_args_list


### PR DESCRIPTION
## Summary

- PR #43 removed BigQuery routing from `/chat/stream`, leaving Gemini 2.5 Pro + Google Search grounding with no backstop against the model misremembering which company a JSE ticker belongs to.
- Reproduced in prod: asking "What was the revenue for MDS in 2025" produced a fabricated claim that the ticker MDS is shared between Medical Disposables & Supplies Limited and Mailpac Group Limited (whose real symbol is MAILPAC). Our own BigQuery metadata shows every one of the 101 JSE symbols maps to exactly one company — this was pure hallucination, not a data-quality artifact.
- Fixes it by reusing the existing two-stage disambiguation pattern from `document_selector.py` (already used by `/chat`'s document auto-loading): an LLM extraction step identifies ticker symbols the query is clearly asking about (so it doesn't mistake a metric abbreviation like "ROC" for a ticker mention — verified this distinction matters, see Testing below), then a deterministic lookup against the real `symbol_to_company` associations builds a verified fact block injected into the Pro call's contents.
- The extraction call runs concurrently with the existing Flash router call (`asyncio.to_thread` + `asyncio.gather`-style overlap) so it doesn't add to total latency in the common case.
- No BigQuery query happens per-request — only a lookup against metadata already loaded at app startup — so this does not reopen the query-parsing bug that PR #43's routing removal fixed.

## Why the harness fix over other options

- **Model upgrade alone isn't the fix**: tested `gemini-3.1-pro-preview` (current frontier Pro tier) against the repro case — it avoided the hallucination in trials, but it's a preview model and the fix shouldn't depend on which model happens to be configured.
- **A static prompt list isn't sufficient either**: `SYSTEM_PROMPT` in `agent_v2.py` already hardcodes a partial "Key JSE Stocks by Sector" list, and the model still hallucinated on a symbol outside that list. Targeted, per-query grounding is what was empirically verified to work.

## Testing

- Reproduced the bug against `gemini-2.5-pro` (current prod model) via local smoke test.
- Verified the fix directly against `gemini-2.5-pro`: 3/3 clean runs on the exact repro query with the grounding note injected, vs. reliable repro without it.
- Checked a risky false-positive case ("What is GraceKennedy ROC for 2024?" — ROC is also a real ticker for IronRock Insurance): confirmed the LLM-based extraction step correctly avoids this collision, unlike a naive regex/substring matcher (which I tested and rejected for this reason).
- Ran the full local smoke test end-to-end (server boot, `/health`, live `/chat/stream` calls) confirming the extraction call fires (visible in logs as an extra `gemini-2.5-flash:generateContent` call), the grounding note gets injected only when a real symbol is found, and normal/non-ticker queries (e.g. "How is the Jamaican economy doing?", "What was NCB revenue in 2025?") are unaffected.
- Added `fastapi_app/tests/test_agent_v2_grounding.py` (11 tests) covering the lookup logic (case-insensitivity, empty-string BigQuery artifact filtering, genuinely-shared-symbol formatting) and `run()` wiring (note injected/not injected, REFUSE path unaffected).
- All 20 `agent_v2` tests pass (9 existing + 11 new). Ran the full suite; the 36 pre-existing failures elsewhere (BigQuery/S3 credential-dependent tests) were confirmed via `git stash` to exist on `main` already and are unrelated to this change.

## Test plan

- [x] Local repro before fix
- [x] Local verification after fix (multiple trials)
- [x] Unit tests for grounding-note logic and `run()` wiring
- [x] Full test suite regression check
- [ ] Remote smoke test on `dev` environment (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)