### PR TITLE
Stamp interaction logs with deploy environment (dev/staging/prod)

### DIFF
--- a/docs/CACHING_LOGGING_TRACING.md
+++ b/docs/CACHING_LOGGING_TRACING.md
@@ -16,10 +16,11 @@ covered.
   if Redis isn't configured.
 - **Interaction logging** (`fastapi_app/app/interaction_log.py`, BigQuery):
   the permanent record of every call (success and failure) — query,
-  response, tokens, cost, latency, cache hit/miss — used for
-  regression/behavior monitoring. Chosen over relying on Langfuse's own
-  (time-limited) trace retention. Fires via `asyncio.create_task(...)` so a
-  logging failure never affects the user-facing request or its latency.
+  response, tokens, cost, latency, cache hit/miss, and which deploy
+  `environment` produced it — used for regression/behavior monitoring.
+  Chosen over relying on Langfuse's own (time-limited) trace retention.
+  Fires via `asyncio.create_task(...)` so a logging failure never affects
+  the user-facing request or its latency.
 - **Langfuse tracing** (`fastapi_app/app/tracing.py`): trace-level
   observability and cost dashboards only — not used for caching (Langfuse
   doesn't do response caching) and not the permanent log (BigQuery is). No-ops
@@ -32,6 +33,27 @@ See `fastapi_app/.env.example` for the full list with defaults
 `LANGFUSE_*`). `REDIS_URL` is already handled by the existing ElastiCache
 Copilot addon (`fastapi_app/copilot/examples/api/addons/redis.yml.example`) —
 no new Redis-specific env var was added.
+
+## Distinguishing environments in BigQuery
+
+`GCP_PROJECT_ID`/`BIGQUERY_DATASET`/`BIGQUERY_INTERACTIONS_TABLE` are declared
+in the Copilot manifest's top-level `variables:` block, not per-environment
+overrides — so unless a project/dataset is deliberately split out per AWS
+environment, dev/staging/prod all write to the same BigQuery table. Every row
+now carries an `environment` column, sourced from `COPILOT_ENVIRONMENT_NAME`
+(injected automatically by AWS Copilot into every container — no new secret
+or config needed). Locally, it falls back to a plain `ENVIRONMENT` env var if
+set, otherwise `NULL`.
+
+**If you already have an `interactions` table without this column** (e.g. the
+dev table from before this change), add it with a lightweight ALTER — BigQuery
+supports adding a NULLABLE column without rewriting existing rows:
+```bash
+bq query --use_legacy_sql=false \
+  'ALTER TABLE `<PROJECT>.<DATASET>.interactions` ADD COLUMN environment STRING'
+```
+Existing rows will show `NULL` for `environment` — safe to treat as "dev"
+if that's the only environment that's been live so far.
 
 ## One-time setup a human needs to do (cannot be run from a sandboxed session)
 

--- a/fastapi_app/.env.example
+++ b/fastapi_app/.env.example
@@ -66,6 +66,12 @@ INTERACTION_LOGGING_ENABLED=true
 BIGQUERY_INTERACTIONS_TABLE=interactions
 # BIGQUERY_INTERACTIONS_DATASET=<YOUR_BIGQUERY_DATASET>  # defaults to BIGQUERY_DATASET if unset
 
+# Deploy environment name, stamped onto every interaction log row so dev/
+# staging/prod can be told apart even when they share a BigQuery table.
+# AWS Copilot sets COPILOT_ENVIRONMENT_NAME automatically - this is only
+# needed for local/non-Copilot runs.
+# ENVIRONMENT=dev
+
 # Langfuse tracing/dashboards (cost visibility only - not used for caching or
 # permanent logging). No-ops when keys are unset.
 LANGFUSE_ENABLED=true

--- a/fastapi_app/app/config.py
+++ b/fastapi_app/app/config.py
@@ -243,6 +243,16 @@ class AppConfig(BaseSettings):
     metadata_key: str = Field(
         default="metadata_2025-11-26.json", description="S3 key for metadata file"
     )
+    environment: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("COPILOT_ENVIRONMENT_NAME", "ENVIRONMENT"),
+        description=(
+            "Deploy environment name (dev/staging/prod/test), used to tag permanent "
+            "logs (e.g. BigQuery interactions) so they can be distinguished across "
+            "environments that otherwise share the same BigQuery project/dataset. "
+            "AWS Copilot auto-injects COPILOT_ENVIRONMENT_NAME into every container."
+        ),
+    )
 
     # Sub-configurations (loaded from environment)
     aws: AWSConfig = Field(default_factory=AWSConfig)

--- a/fastapi_app/app/interaction_log.py
+++ b/fastapi_app/app/interaction_log.py
@@ -27,6 +27,7 @@ logger = get_logger(__name__)
 INTERACTIONS_SCHEMA = [
     bigquery.SchemaField("interaction_id", "STRING", mode="REQUIRED"),
     bigquery.SchemaField("request_id", "STRING", mode="NULLABLE"),
+    bigquery.SchemaField("environment", "STRING", mode="NULLABLE"),
     bigquery.SchemaField("endpoint", "STRING", mode="REQUIRED"),
     bigquery.SchemaField("timestamp", "TIMESTAMP", mode="REQUIRED"),
     bigquery.SchemaField("query", "STRING", mode="REQUIRED"),
@@ -59,10 +60,12 @@ class InteractionLogger:
         dataset: Optional[str],
         table: str,
         enabled: bool = True,
+        environment: Optional[str] = None,
     ):
         self._client = bq_client
         self._table_ref = f"{dataset}.{table}" if bq_client and dataset else None
         self._enabled = bool(enabled and bq_client is not None and self._table_ref)
+        self._environment = environment
 
     @property
     def enabled(self) -> bool:
@@ -124,6 +127,7 @@ class InteractionLogger:
     async def log(self, row: Dict[str, Any]) -> None:
         if not self._enabled:
             return
+        row = {**row, "environment": self._environment}
         try:
             errors = await asyncio.to_thread(self._client.insert_rows_json, self._table_ref, [row])
             if errors:
@@ -165,4 +169,5 @@ def build_interaction_logger() -> InteractionLogger:
         dataset=cfg.bigquery.resolved_interactions_dataset,
         table=cfg.bigquery.interactions_table,
         enabled=cfg.bigquery.logging_enabled,
+        environment=cfg.environment,
     )

--- a/fastapi_app/tests/conftest.py
+++ b/fastapi_app/tests/conftest.py
@@ -79,7 +79,17 @@ def mock_config():
     config.gcp.api_key = "test-api-key"
     config.bigquery.dataset = "test-dataset"
     config.bigquery.table = "test-table"
+    config.bigquery.interactions_table = "test_interactions"
+    config.bigquery.resolved_interactions_dataset = "test-dataset"
+    config.bigquery.logging_enabled = False
     config.redis.url = None
+    config.redis.response_cache_enabled = True
+    config.redis.response_cache_ttl_seconds = 3600
+    config.langfuse.public_key = None
+    config.langfuse.secret_key = None
+    config.langfuse.enabled = True
+    config.langfuse.configured = False
+    config.environment = None
     config.log_level = "INFO"
     return config
 

--- a/fastapi_app/tests/unit/test_interaction_log.py
+++ b/fastapi_app/tests/unit/test_interaction_log.py
@@ -58,7 +58,19 @@ async def test_log_calls_insert_rows_json():
     client.insert_rows_json.assert_called_once()
     args, _ = client.insert_rows_json.call_args
     assert args[0] == "ds.interactions"
-    assert args[1] == [{"query": "x"}]
+    assert args[1] == [{"query": "x", "environment": None}]
+
+
+@pytest.mark.asyncio
+async def test_log_stamps_configured_environment_onto_every_row():
+    client = MagicMock()
+    client.insert_rows_json.return_value = []
+    logger_ = InteractionLogger(
+        bq_client=client, dataset="ds", table="interactions", enabled=True, environment="dev"
+    )
+    await logger_.log({"query": "x"})
+    args, _ = client.insert_rows_json.call_args
+    assert args[1] == [{"query": "x", "environment": "dev"}]
 
 
 @pytest.mark.asyncio
@@ -83,6 +95,19 @@ def test_build_interaction_logger_disabled_when_logging_disabled():
     mock_config.bigquery.resolved_interactions_dataset = "ds"
     mock_config.bigquery.interactions_table = "interactions"
     mock_config.gcp.project_id = "proj"
+    mock_config.environment = None
     with patch("app.config.get_config", return_value=mock_config):
         logger_ = build_interaction_logger()
     assert logger_.enabled is False
+
+
+def test_build_interaction_logger_passes_environment_through():
+    mock_config = MagicMock()
+    mock_config.bigquery.logging_enabled = False
+    mock_config.bigquery.resolved_interactions_dataset = "ds"
+    mock_config.bigquery.interactions_table = "interactions"
+    mock_config.gcp.project_id = "proj"
+    mock_config.environment = "staging"
+    with patch("app.config.get_config", return_value=mock_config):
+        logger_ = build_interaction_logger()
+    assert logger_._environment == "staging"


### PR DESCRIPTION
## Summary

Follow-up to #42. You noticed the `interactions` BigQuery table can't distinguish dev from prod rows — confirmed that's an oversight, not by design:

- `GCP_PROJECT_ID`/`BIGQUERY_DATASET`/`BIGQUERY_INTERACTIONS_TABLE` are all declared in the Copilot manifest's top-level `variables:` block, not per-environment overrides, so dev/staging/prod all write to the same BigQuery table by default.
- The row schema had no field identifying which environment produced a row.

Fix: adds an `environment` column to `INTERACTIONS_SCHEMA`, populated from `COPILOT_ENVIRONMENT_NAME` — AWS Copilot already auto-injects this into every container (it's the same mechanism the manifest's `${COPILOT_ENVIRONMENT_NAME}` SSM paths rely on), so no new secret or config is needed. Falls back to a plain `ENVIRONMENT` env var for local/non-Copilot runs. `docs/CACHING_LOGGING_TRACING.md` has the `ALTER TABLE ... ADD COLUMN` command for the existing dev table (BigQuery supports adding a nullable column without a rewrite; old rows will just show `NULL`).

Also fixed while reviewing: `mock_config` in `tests/conftest.py` never explicitly set the `bigquery.logging_enabled`/`langfuse.*`/`environment` fields added in #42, so `Mock()` auto-vivified them as truthy — meaning `build_interaction_logger()` and `get_langfuse_client()` were silently attempting real client construction (with garbage Mock values) on every relevant test run, caught by their own exception handling but noisy/wasteful. Now explicitly disabled in tests.

## Test plan

- [x] `pytest tests/unit tests/integration/test_api_endpoints.py tests/test_agent_v2_grounding.py tests/test_agent_v2_router.py tests/test_api.py tests/test_chat_stream_endpoint.py` — 125 passed
- [x] `black`/`ruff` clean
- [ ] For the already-provisioned dev BigQuery table: run the `ALTER TABLE` command in `docs/CACHING_LOGGING_TRACING.md` so the column exists before this deploys

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZWV8AoEr8f2NuCqqqHWvL)_