### PR TITLE
fix(redis): point ElastiCache addon at PublicSubnets

### DIFF
--- a/docs/CACHING_LOGGING_TRACING.md
+++ b/docs/CACHING_LOGGING_TRACING.md
@@ -83,6 +83,18 @@ if that's the only environment that's been live so far.
    environment's CloudFormation stack Outputs for `RedisUrl`. If missing,
    copy `redis.yml.example` to the real `copilot/api/addons/redis.yml` before
    deploying.
+
+   ⚠️ **Needs a security/policy sanity check (open as of 2026-08-15):** this
+   app's environments only export `PublicSubnets`, not `PrivateSubnets`, so
+   `redis.yml.example` was changed to place the ElastiCache node in a
+   publicly-routed subnet (see the note inline in that file). It's not
+   internet-reachable in practice — no public IP is assigned, and the
+   addon's security group only allows traffic from the environment's own
+   security group — but putting a datastore in a public subnet at all is
+   worth a second opinion from whoever owns security/compliance here before
+   this pattern is reused for staging/prod, or before anything sensitive is
+   ever cached. First deployed to **dev** on 2026-08-15 as a follow-up to
+   #45.
 6. **Deploy**: `copilot svc deploy --name api --env staging --profile ats-jse-elroy` (repeat per environment).
 7. **Smoke test**: send the same `/fast_chat_v2` or `/chat/stream` query
    twice with no conversation history — the second call should be

--- a/fastapi_app/copilot/examples/api/addons/redis.yml.example
+++ b/fastapi_app/copilot/examples/api/addons/redis.yml.example
@@ -36,6 +36,16 @@ Resources:
               !Sub "${App}-${Env}-EnvironmentSecurityGroup"
 
   # Redis Subnet Group
+  # NOTE (2026-08-15): this app's Copilot environments (dev/prod) only export
+  # a PublicSubnets value, not PrivateSubnets -- deploying against
+  # PrivateSubnets fails with "No export named ...-PrivateSubnets found".
+  # Using PublicSubnets here means the ElastiCache node sits in a
+  # publicly-routed subnet. It's not internet-reachable in practice (no
+  # public IP is assigned, and RedisSecurityGroup above only allows traffic
+  # from EnvironmentSecurityGroup), but this is still a network-placement
+  # tradeoff someone should sanity-check against org security/compliance
+  # policy before this pattern gets reused for staging/prod, or before any
+  # sensitive data is ever cached here. See docs/CACHING_LOGGING_TRACING.md.
   RedisSubnetGroup:
     Type: AWS::ElastiCache::SubnetGroup
     Properties:
@@ -44,7 +54,7 @@ Resources:
         Fn::Split:
           - ","
           - Fn::ImportValue:
-              !Sub "${App}-${Env}-PrivateSubnets"
+              !Sub "${App}-${Env}-PublicSubnets"
 
   # Redis Cluster (Single Node for cost efficiency)
   # Using cache.t3.micro which is free-tier eligible in some regions or very cheap


### PR DESCRIPTION
## Summary

Follow-up to #45. While chasing why the response cache never recorded a single `cache_hit=true`, found the Redis ElastiCache Copilot addon had never actually been deployed anywhere — only the sanitized `redis.yml.example` template existed, never copied to the real (gitignored) `copilot/api/addons/redis.yml`.

Deploying it as-written fails: `redis.yml.example` references `${App}-${Env}-PrivateSubnets`, but this app's Copilot environment stacks (checked both `dev` and `prod` via `aws cloudformation list-exports`) only export `PublicSubnets` — no private subnets exist anywhere in this app's infra.

- Fixed the subnet reference to `PublicSubnets` in the tracked example template, with an inline comment explaining why and the tradeoff involved.
- Added a note to `docs/CACHING_LOGGING_TRACING.md` step 5 flagging this as an open security/policy review item — the ElastiCache node isn't internet-reachable in practice (no public IP assigned, and `RedisSecurityGroup` only allows traffic from the environment's own `EnvironmentSecurityGroup`), but placing any datastore in a publicly-routed subnet is a real design tradeoff someone owning security/compliance should sign off on before this pattern is reused for staging/prod.

Deployed to **dev** with this fix as part of this same investigation.

## Test plan

- [x] Deployed the fixed addon to dev via `copilot svc deploy --name api --env dev`
- [ ] Security/policy review of the public-subnet placement before reuse in staging/prod (tracked in the docs note)

---
_Generated by [Claude Code](https://claude.ai/code)_