### PR TITLE
fix: un-silence ruff on app/main.py and repair two broken endpoints

### DIFF
--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1,47 +1,49 @@
-from fastapi import FastAPI, HTTPException, Depends, Request
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse, JSONResponse, Response
+import asyncio
 import time
 import uuid
-import asyncio
-from datetime import datetime, timezone
-from typing import Dict, Any
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any, Dict
 
-from app.models import (
-    ChatRequest,
-    ChatResponse,
-    ChartSpec,
-    FinancialDataRequest,
-    FinancialDataResponse,
-    AgentChatRequest,
-    AgentChatResponse,
-)
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from app.agent_v2 import AgentV2
 from app.charting import generate_chart
-from app.s3_client import init_s3_client
-from app.gemini_client import (
-    init_vertex_ai,
-    generate_chat_response,
-    refresh_metadata_cache,
-    get_cache_status,
-)
-from app.metadata_loader import load_metadata_from_s3
+from app.config import get_config
 from app.document_selector import auto_load_relevant_documents
 from app.financial_utils import FinancialDataManager
-from app.agent_v2 import AgentV2
-from app.config import get_config
-from app.response_cache import ResponseCache, build_response_cache
+from app.gemini_client import (
+    generate_chat_response,
+    get_cache_status,
+    init_vertex_ai,
+    refresh_metadata_cache,
+)
 from app.interaction_log import InteractionLogger, build_interaction_logger
-from app.tracing import get_langfuse_client, traced_observation
 from app.logging_config import configure_logging, get_logger
-from app.middleware.request_id import RequestIDMiddleware
+from app.metadata_loader import load_metadata_from_s3
 from app.middleware.metrics import (
     PrometheusMetricsMiddleware,
     get_metrics,
     get_metrics_content_type,
 )
-
-from dotenv import load_dotenv
+from app.middleware.request_id import RequestIDMiddleware
+from app.models import (
+    AgentChatRequest,
+    AgentChatResponse,
+    ChartSpec,
+    ChatRequest,
+    ChatResponse,
+    FinancialDataFilters,
+    FinancialDataRecord,
+    FinancialDataRequest,
+    FinancialDataResponse,
+)
+from app.response_cache import ResponseCache, build_response_cache
+from app.s3_client import init_s3_client
+from app.tracing import get_langfuse_client, traced_observation
 
 load_dotenv()
 
@@ -800,11 +802,11 @@ async def get_cache_status_endpoint():
 
 
 @app.post("/cache/refresh")
-async def refresh_cache_endpoint():
+async def refresh_cache_endpoint(s3_client: Any = Depends(get_s3_client)):
     """Force refresh of the metadata cache using current S3 metadata"""
     try:
         # Load current metadata from S3
-        metadata = load_metadata_from_s3()
+        metadata = load_metadata_from_s3(s3_client)
         if not metadata:
             raise HTTPException(status_code=500, detail="Failed to load metadata from S3")
 

--- a/fastapi_app/pyproject.toml
+++ b/fastapi_app/pyproject.toml
@@ -104,7 +104,8 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Unused imports in __init__.py
 "tests/*" = ["F401", "F811"]  # Allow test fixtures
-"app/streaming_chat.py" = ["E", "W", "F", "I", "B", "C4"]  # Excluded in pre-commit
+# app/streaming_chat.py moved to app/_archive/ and lints clean, so it needs no
+# exemption. Re-add one only if a file actually requires it.
 # Leading slash anchors this to the repo-root uvicorn shim. Without it the bare
 # pattern also matches app/main.py by basename, silencing every lint rule on the
 # entire API surface (that masked an F821 undefined-name that reached prod).
@@ -132,6 +133,11 @@ markers = [
 
 [tool.mypy]
 python_version = "3.10"
+# Without this, app/utils/*.py resolves as both `app.utils.*` and
+# `fastapi_app.app.utils.*` (fastapi_app/__init__.py makes the parent a
+# package). mypy treats that as a fatal error and exits before checking
+# anything, so the CI step has never type-checked a single file.
+explicit_package_bases = true
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/fastapi_app/pyproject.toml
+++ b/fastapi_app/pyproject.toml
@@ -105,7 +105,10 @@ ignore = [
 "__init__.py" = ["F401"]  # Unused imports in __init__.py
 "tests/*" = ["F401", "F811"]  # Allow test fixtures
 "app/streaming_chat.py" = ["E", "W", "F", "I", "B", "C4"]  # Excluded in pre-commit
-"main.py" = ["E", "W", "F", "I", "B", "C4"]  # Excluded in pre-commit
+# Leading slash anchors this to the repo-root uvicorn shim. Without it the bare
+# pattern also matches app/main.py by basename, silencing every lint rule on the
+# entire API surface (that masked an F821 undefined-name that reached prod).
+"/main.py" = ["E", "W", "F", "I", "B", "C4"]  # Excluded in pre-commit
 "test_async_integration.py" = ["E", "W", "F", "I", "B", "C4"]  # Excluded in pre-commit
 
 [tool.pytest.ini_options]

--- a/fastapi_app/tests/integration/test_api_endpoints.py
+++ b/fastapi_app/tests/integration/test_api_endpoints.py
@@ -1,11 +1,12 @@
 """Integration tests for API endpoints."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, create_autospec, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from app.main import app
+from app.main import app, get_response_cache_dep
+from app.metadata_loader import load_metadata_from_s3 as real_load_metadata_from_s3
 
 
 @pytest.mark.integration
@@ -115,8 +116,144 @@ class TestCacheEndpoints:
         assert response.status_code in [200, 404, 500]
 
     def test_cache_refresh_endpoint(self, client):
-        """Test /cache/refresh endpoint."""
+        """Test /cache/refresh endpoint succeeds when S3 metadata loads.
+
+        Regression test: the handler used to call load_metadata_from_s3() with no
+        arguments while the function requires an s3_client, so every call raised
+        TypeError and returned a 500. Asserting on 200 specifically — the previous
+        assertion accepted 500 and so never caught it.
+        """
         with patch("app.main.refresh_metadata_cache") as mock_refresh:
-            mock_refresh.return_value = {"status": "refreshed"}
+            mock_refresh.return_value = True
             response = client.post("/cache/refresh")
-            assert response.status_code in [200, 404, 500]
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    def test_cache_refresh_passes_s3_client_to_loader(self, client):
+        """The S3 client from app state must reach the metadata loader.
+
+        The signature spec is what gives this test its teeth: the shared autouse
+        mock in conftest accepts any arguments, so an argument-less call looks
+        fine to it. Speccing against the real load_metadata_from_s3(s3_client)
+        makes that call raise TypeError the way it does in production. It is
+        built with create_autospec and injected via new=, because patch(...,
+        autospec=True) refuses to spec an attribute conftest already mocked out.
+        """
+        spec_loader = create_autospec(real_load_metadata_from_s3)
+        spec_loader.return_value = {"companies": []}
+
+        with patch("app.main.refresh_metadata_cache", return_value=True):
+            with patch("app.main.load_metadata_from_s3", new=spec_loader) as mock_load:
+                response = client.post("/cache/refresh")
+
+        assert response.status_code == 200
+        mock_load.assert_called_once()
+        # Called positionally with the client, not with an empty argument list.
+        assert mock_load.call_args.args[0] is app.state.s3_client
+
+
+@pytest.mark.integration
+class TestFastChatV2Cache:
+    """Test the /fast_chat_v2 response-cache branch.
+
+    This branch had zero coverage and referenced two names that were never
+    imported into app.main, so every cache hit raised NameError and surfaced to
+    the caller as a 500.
+    """
+
+    @pytest.fixture
+    def client(self, test_client):
+        return test_client
+
+    @pytest.fixture
+    def cached_payload(self):
+        """A payload shaped exactly like what the endpoint writes to Redis."""
+        return {
+            "response": "NCB 2023 revenue was J$1.20B.",
+            "data_found": True,
+            "record_count": 1,
+            "filters_used": {
+                "companies": ["NCB Financial Group"],
+                "symbols": ["NCBFG"],
+                "years": ["2023"],
+                "standard_items": ["revenue"],
+                "interpretation": "NCB revenue for 2023",
+                "is_follow_up": False,
+            },
+            "data_preview": [
+                {
+                    "company": "NCB Financial Group",
+                    "symbol": "NCBFG",
+                    "year": "2023",
+                    "standard_item": "revenue",
+                    "item": 1.2,
+                    "unit_multiplier": 1000000000,
+                    "formatted_value": "1.20B",
+                }
+            ],
+            "warnings": None,
+            "suggestions": None,
+            "chart": None,
+        }
+
+    @pytest.fixture
+    def cache_hit(self, cached_payload):
+        """Override the cache dependency so every lookup is a hit."""
+        cache = Mock()
+        cache.get = AsyncMock(return_value=cached_payload)
+        cache.set = AsyncMock()
+        app.dependency_overrides[get_response_cache_dep] = lambda: cache
+        yield cache
+        app.dependency_overrides.pop(get_response_cache_dep, None)
+
+    def test_cache_hit_returns_200(self, client, cache_hit, cached_payload):
+        """A cache hit must return the cached answer, not a 500."""
+        response = client.post(
+            "/fast_chat_v2",
+            json={"query": "NCB revenue 2023", "memory_enabled": False},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["response"] == cached_payload["response"]
+        assert body["data_found"] is True
+        assert body["record_count"] == 1
+
+    def test_cache_hit_rehydrates_filters_and_preview(self, client, cache_hit):
+        """The cached dicts must round-trip back into their Pydantic models."""
+        response = client.post(
+            "/fast_chat_v2",
+            json={"query": "NCB revenue 2023", "memory_enabled": False},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["filters_used"]["symbols"] == ["NCBFG"]
+        assert body["filters_used"]["years"] == ["2023"]
+        assert body["data_preview"][0]["formatted_value"] == "1.20B"
+
+    def test_cache_hit_skips_the_financial_manager(self, client, cache_hit):
+        """A hit must short-circuit before any paid Gemini or BigQuery work."""
+        with patch("app.main.asyncio.to_thread") as mock_to_thread:
+            response = client.post(
+                "/fast_chat_v2",
+                json={"query": "NCB revenue 2023", "memory_enabled": False},
+            )
+
+        assert response.status_code == 200
+        mock_to_thread.assert_not_called()
+
+    def test_conversation_history_bypasses_the_cache(self, client, cache_hit):
+        """Follow-ups depend on context the cache doesn't key on, so never serve them."""
+        response = client.post(
+            "/fast_chat_v2",
+            json={
+                "query": "what about 2022?",
+                "memory_enabled": False,
+                "conversation_history": [{"role": "user", "content": "NCB revenue 2023"}],
+            },
+        )
+
+        cache_hit.get.assert_not_called()
+        assert response.status_code in [200, 500]  # Falls through to the live path.

--- a/fastapi_app/tests/integration/test_api_endpoints.py
+++ b/fastapi_app/tests/integration/test_api_endpoints.py
@@ -257,3 +257,93 @@ class TestFastChatV2Cache:
 
         cache_hit.get.assert_not_called()
         assert response.status_code in [200, 500]  # Falls through to the live path.
+
+
+@pytest.mark.integration
+class TestChatStreamCache:
+    """Test the /chat/stream response-cache branch.
+
+    The sibling of the /fast_chat_v2 branch above, and equally uncovered. It
+    survives because it hands the cached dicts straight to AgentChatResponse and
+    lets Pydantic coerce them, rather than naming the models explicitly — which
+    is exactly what broke /fast_chat_v2. These tests pin that coercion down so a
+    future refactor toward explicit construction cannot silently repeat it.
+    """
+
+    @pytest.fixture
+    def client(self, test_client):
+        return test_client
+
+    @pytest.fixture
+    def cache_hit(self):
+        cached = {
+            "response": "GraceKennedy outperformed NCB on 2023 revenue growth.",
+            "data_found": True,
+            "record_count": 2,
+            "filters_used": {
+                "companies": ["GraceKennedy", "NCB Financial Group"],
+                "symbols": ["GK", "NCBFG"],
+                "years": ["2023"],
+                "standard_items": ["revenue"],
+                "interpretation": "GK vs NCB revenue for 2023",
+                "is_follow_up": False,
+            },
+            "data_preview": [
+                {
+                    "company": "GraceKennedy",
+                    "symbol": "GK",
+                    "year": "2023",
+                    "standard_item": "revenue",
+                    "item": 1.6,
+                    "unit_multiplier": 1000000000,
+                    "formatted_value": "1.60B",
+                }
+            ],
+            "warnings": None,
+            "suggestions": None,
+            "chart": None,
+            # Matches the shape AgentV2 builds from Google Search grounding chunks.
+            "sources": [
+                {
+                    "type": "web",
+                    "title": "Jamaica Stock Exchange",
+                    "url": "https://www.jamstockex.com/",
+                }
+            ],
+            "web_search_results": None,
+            "tools_executed": ["financial_data"],
+            "needs_clarification": False,
+            "clarification_question": None,
+        }
+        cache = Mock()
+        cache.get = AsyncMock(return_value=cached)
+        cache.set = AsyncMock()
+        app.dependency_overrides[get_response_cache_dep] = lambda: cache
+        yield cache
+        app.dependency_overrides.pop(get_response_cache_dep, None)
+
+    def test_cache_hit_returns_200_without_invoking_the_agent(self, client, cache_hit):
+        """A hit must short-circuit before AgentV2 is constructed — no paid call."""
+        with patch("app.main.AgentV2") as MockAgent:
+            response = client.post(
+                "/chat/stream",
+                json={"query": "compare GK and NCB revenue", "memory_enabled": False},
+            )
+
+        assert response.status_code == 200
+        MockAgent.assert_not_called()
+
+    def test_cache_hit_coerces_nested_models(self, client, cache_hit):
+        """Cached dicts must survive the round-trip through AgentChatResponse."""
+        response = client.post(
+            "/chat/stream",
+            json={"query": "compare GK and NCB revenue", "memory_enabled": False},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["record_count"] == 2
+        assert body["filters_used"]["symbols"] == ["GK", "NCBFG"]
+        assert body["data_preview"][0]["formatted_value"] == "1.60B"
+        assert body["sources"][0]["url"] == "https://www.jamstockex.com/"
+        assert body["tools_executed"] == ["financial_data"]


### PR DESCRIPTION
## Why

A production-readiness review turned up two endpoints that fail on every call, plus the reason nothing caught them.

The `[tool.ruff.lint.per-file-ignores]` entry `"main.py"` was written for the 17-line uvicorn shim at `fastapi_app/main.py`. Ruff matches bare filename patterns against the **basename**, so it also matched `app/main.py` — silencing every lint rule (`E`, `W`, `F`, `I`, `B`, `C4`) across the entire 1,042-line API surface.

Verified directly:

```
$ ruff check app/main.py --select F821            # project config
All checks passed!

$ ruff check --isolated app/main.py --select F821
F821 Undefined name `FinancialDataFilters`
   --> app/main.py:608:23
```

## What this fixes

**1. `/fast_chat_v2` returned a 500 on every Redis cache hit.** The cache-hit branch constructs `FinancialDataFilters` and `FinancialDataRecord`, but neither name was imported. The first identical query warmed the cache; the second raised `NameError`, was swallowed by the endpoint's `except Exception`, and reached the caller as `500 Error processing financial data query`. The response cache was not merely inert on this endpoint — it was actively harmful.

**2. `POST /cache/refresh` could never succeed.** It called `load_metadata_from_s3()` with no arguments while the function requires an `s3_client` (the startup path passes it correctly). Every call raised `TypeError` and returned a 500, so the documented recovery path for stale metadata did not work. The client now arrives via `Depends(get_s3_client)`, matching the other handlers.

**3. The ignore pattern is anchored** as `"/main.py"`, with a comment explaining why the leading slash matters.

**4. mypy has never type-checked a single file.** `app/utils/*.py` resolves as both `app.utils.*` and `fastapi_app.app.utils.*` — `fastapi_app/__init__.py` makes the parent a package — and mypy treats that as fatal, exiting before it checks anything. The CI step then swallows the abort twice over, via `|| echo` and `continue-on-error: true`. Setting `explicit_package_bases` lets it run. It now reports **100 errors across 17 files**, including the missing annotation on `request_costs` in `main.py`. Left non-blocking — turning those 100 into a gate is its own piece of work — but the step now produces real output instead of a module-resolution error.

**5. Removed the dead per-file-ignore** for `app/streaming_chat.py`; that file moved to `app/_archive/` and lints clean where it now lives.

## Tests

Both defects sat on lines with zero coverage. Seven tests added.

`/fast_chat_v2` cache branch:
- a cache hit returns 200 with the cached answer
- cached dicts rehydrate into `FinancialDataFilters` / `FinancialDataRecord`
- a hit short-circuits before any paid Gemini or BigQuery work
- conversation history bypasses the cache entirely
- `/cache/refresh` passes the S3 client through to the loader

`/chat/stream` cache branch — the sibling of the broken one, equally uncovered. It works today only because it hands the cached dicts to `AgentChatResponse` and lets Pydantic coerce them, rather than naming the models explicitly the way the broken branch did. Two tests pin that down so a future refactor toward explicit construction cannot silently repeat the bug:
- a hit returns 200 without constructing `AgentV2` (no paid call)
- nested dicts survive the round-trip into `filters_used` / `data_preview` / `sources`

The five tests covering pre-existing behaviour were each confirmed to fail against the pre-fix code, then pass after.

Two notes on the mocks. The `/cache/refresh` guard specs its mock with `create_autospec` against the real loader, because the shared autouse mock in `conftest.py` accepts any signature and so cannot catch an argument-less call on its own — that permissiveness is systemic, and worth a separate pass. It uses `new=` rather than `autospec=True` because `patch` refuses to autospec an attribute conftest has already mocked out.

The pre-existing `test_cache_refresh_endpoint` asserted `status_code in [200, 404, 500]`, which accepted the bug; it now asserts 200.

## Results

```
108 passed  (was 101)
app/main.py coverage:  46.15% -> 61.03%
total coverage:        40.71% -> 42.82%
ruff check .           All checks passed!
black --check .        66 files unchanged
mypy app/              runs for the first time; 100 errors reported, non-blocking
```

The only lint change to source beyond the fixes is an import re-sort (`I001`), applied with `ruff --fix`.

## Not in this PR

The wider readiness findings are separate work, in rough priority order: the pre-commit CI job is a no-op (`cd fastapi_app && pre-commit run --all-files || true` — wrong directory, and the failure is swallowed); there is no auth or rate limiting on the paid endpoints; coverage is enforced at zero against a README claiming 80%; the suites at the root of `tests/` are excluded from CI and currently fail 36/44, about half from one malformed credential stub in `conftest.py`; and the lint job runs from `fastapi_app/`, so `evals/`, `scripts/`, and `loadtest/` are never linted at all.