### PR TITLE
fix(monitoring): add ELB-origin 5xx alarm (target-response-blocked outages were invisible)

### DIFF
--- a/infra/monitoring/chatbot-alarms.yml
+++ b/infra/monitoring/chatbot-alarms.yml
@@ -185,7 +185,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub jse-datasphere-chatbot-${Env}-alb-5xx
-      AlarmDescription: 'ALB is seeing 5xx responses from the api targets.'
+      AlarmDescription: 'ALB is seeing 5xx responses that the api target itself returned (app-level error handling, not a hang).'
       Namespace: AWS/ApplicationELB
       MetricName: HTTPCode_Target_5XX_Count
       Dimensions:
@@ -202,11 +202,41 @@ Resources:
       AlarmActions: [!Ref AlertTopic]
       OKActions: [!Ref AlertTopic]
 
+  # Separate from Alb5xxAlarm on purpose. HTTPCode_Target_5XX_Count only
+  # counts 5xx status codes the target *returned*. When the target never
+  # responds at all (e.g. the app's event loop is blocked and the request
+  # just queues forever), the ALB itself gives up and manufactures a 504 -
+  # that shows up here, under HTTPCode_ELB_5XX_Count, not on the target
+  # metric. Confirmed against real data from the 2026-08-15 load test
+  # outage (see docs/adr/0001-fix-event-loop-blocking-llm-calls.md): during
+  # the failing burst, HTTPCode_ELB_5XX_Count spiked to 16 in one 5-minute
+  # period while HTTPCode_Target_5XX_Count recorded zero. Without this
+  # alarm, a full "server never responds" outage is invisible to 5xx-based
+  # alerting even though real users are seeing errors.
+  AlbElb5xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub jse-datasphere-chatbot-${Env}-alb-elb-5xx
+      AlarmDescription: 'ALB itself is generating 5xx (typically 504) because the api target is not responding at all - a hang/serialization outage, not an app-level error.'
+      Namespace: AWS/ApplicationELB
+      MetricName: HTTPCode_ELB_5XX_Count
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !Ref LoadBalancerArnSuffix
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+      OKActions: [!Ref AlertTopic]
+
   LatencyAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub jse-datasphere-chatbot-${Env}-p99-latency
-      AlarmDescription: !Sub 'p99 target response time exceeded ${LatencyThresholdSeconds}s (a normal chat/synthesis call runs 7-40s; this catches genuine hangs like the 180s Aug 11 outlier).'
+      AlarmDescription: !Sub 'p99 target response time exceeded ${LatencyThresholdSeconds}s (a normal chat/synthesis call runs 7-40s; this catches genuine slow-but-responding hangs like the 180s Aug 11 outlier). Known gap: TargetResponseTime has no data point at all for a request the target never responded to (confirmed zero samples during the 2026-08-15 outage window) - a total non-response outage relies on AlbElb5xxAlarm / NoHealthyHostsAlarm instead, not this one.'
       Namespace: AWS/ApplicationELB
       MetricName: TargetResponseTime
       Dimensions:
@@ -278,10 +308,11 @@ Resources:
 
             { "type": "metric", "x": 8, "y": 7, "width": 8, "height": 6,
               "properties": {
-                "title": "ALB 5xx",
+                "title": "ALB 5xx (target-returned vs ALB-generated)",
                 "view": "timeSeries", "stacked": false, "region": "${AWS::Region}",
                 "metrics": [
-                  [ "AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", "${LoadBalancerArnSuffix}", "TargetGroup", "${TargetGroupArnSuffix}", { "stat": "Sum" } ]
+                  [ "AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", "${LoadBalancerArnSuffix}", "TargetGroup", "${TargetGroupArnSuffix}", { "stat": "Sum", "label": "Target 5xx (app returned it)" } ],
+                  [ "AWS/ApplicationELB", "HTTPCode_ELB_5XX_Count", "LoadBalancer", "${LoadBalancerArnSuffix}", { "stat": "Sum", "label": "ELB 5xx (ALB gave up, no response)" } ]
                 ]
               } },
 


### PR DESCRIPTION
## Summary

While auditing whether prod's monitoring would have caught the outage from the load test in [ADR 0001](docs/adr/0001-fix-event-loop-blocking-llm-calls.md), found it wouldn't have — for a specific, confirmed reason.

`Alb5xxAlarm` watches `HTTPCode_Target_5XX_Count`: 5xx codes the target itself returns. When the target never responds at all (the exact failure mode ADR 0001 fixed — a blocked event loop means the app never sends any response), the ALB times out and manufactures the 504 itself, under a completely different metric: `HTTPCode_ELB_5XX_Count`. Nothing was watching that one.

Verified against real CloudWatch data from the 2026-08-15 test:
- `HTTPCode_ELB_5XX_Count` spiked to **16** in the failing 5-minute window.
- `HTTPCode_Target_5XX_Count` recorded **zero** in that same window.
- `TargetResponseTime` (what `LatencyAlarm` watches) also recorded **zero samples** in that window — a target that never responds has no response time to record, so the p99 latency alarm is independently blind to this same failure mode.

## Changes

- Adds `AlbElb5xxAlarm` watching `HTTPCode_ELB_5XX_Count`, same threshold/period style as the existing `Alb5xxAlarm`.
- Documents the `TargetResponseTime` blind spot directly on `LatencyAlarm`'s description rather than trying to paper over it with `TreatMissingData` (a "no traffic at 3am" case and a "total outage" case both look like missing data — the new ELB alarm is the more direct signal for the outage case).
- Adds `HTTPCode_ELB_5XX_Count` as a second series on the dashboard's "ALB 5xx" widget.

## Deploy plan

Once merged, redeploy the standalone stack (not part of Copilot):
```bash
aws cloudformation deploy --template-file infra/monitoring/chatbot-alarms.yml \
  --stack-name jse-datasphere-chatbot-prod-monitoring \
  --parameter-overrides Env=prod ClusterName=jse-datasphere-chatbot-prod-Cluster-6xeFgs2NAs0Q \
    ServiceName=jse-datasphere-chatbot-prod-api-Service-j609aKELOJ8V \
    LogGroupName=/copilot/jse-datasphere-chatbot-prod-api \
    LoadBalancerArnSuffix=app/jse-da-Publi-2tSlV7zf7Ysl/a68d9f1271551dee \
    TargetGroupArnSuffix=targetgroup/jse-da-Targe-BC7EFEDOEBZO/58c88036dfc66af3 \
    AlertEmail=elroy.galbraith@gmail.com
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)