### PR TITLE
perf: native async Gemini client (#52) — 7.6x throughput, removes the 504 cliff

### DIFF
--- a/docs/adr/0002-stagger-onboarding-waves-during-testing.md
+++ b/docs/adr/0002-stagger-onboarding-waves-during-testing.md
@@ -1,0 +1,113 @@
+# ADR 0002: Stagger onboarding invitations in waves while capacity is unproven
+
+## Status
+
+Accepted (2026-08-16). **Not applied to the first beta wave** — all 100
+invitations had already been sent when this decision was taken. This ADR
+governs subsequent waves.
+
+## Context
+
+The chatbot entered beta with onboarding invitations sent to 100 potential
+users. All 100 went out at once.
+
+The capacity picture at the time of that send:
+
+- [ADR 0001](0001-fix-event-loop-blocking-llm-calls.md) removed the
+  event-loop-blocking bug and verified the fix, but **only up to concurrency
+  8**. Above that, behaviour is unmeasured.
+- The ADR 0001 numbers do not establish a ceiling. Dev (1 ECS task) recorded
+  0.38 rps at concurrency 8 and prod (2 tasks) recorded 0.36 rps at the same
+  level. Prod has twice the capacity and produced the same throughput, which
+  is the signature of a test bounded by the load generator rather than by the
+  server: at concurrency 8 with ~22s service time, throughput is 8 ÷ 22s
+  regardless of which end is the constraint. The real limit was never found.
+- A `/health` sweep against dev on 2026-08-16 returned 69 rps at concurrency
+  32 with 0% errors and sub-10ms server time, confirming the ALB, network and
+  container are not the near-term constraint. Whatever the limit is, it is in
+  the application path.
+- Each `/chat/stream` request takes ~13–20s, nearly all of it Gemini time.
+
+The risk this creates is not steady-state load. 100 users accumulated over a
+month is roughly 0.07 rps average — far below anything measured. The risk is
+**correlated arrival**: invitations delivered simultaneously produce
+click-throughs that cluster within hours of each other. A plausible first-day
+pattern for 100 invitations is 5–15 concurrent sessions, which straddles the
+highest level ever verified.
+
+The failure mode when that ceiling is crossed is not graceful. Pre-fix, a
+concurrency-8 load test produced 17 real HTTP 504s for production users
+(ADR 0001). Post-fix the same level is clean, but the shape of failure above
+the tested range is unknown, and 504s remain the likely form.
+
+The cost of that failure is unusually high in a beta. The people who would
+receive the timeouts are the same people being asked to evaluate the product,
+and a first impression that times out is not recovered by a later fix.
+
+## Decision
+
+While measured capacity remains below projected peak concurrency, onboarding
+invitations are sent in **waves**, not in a single batch.
+
+- Default wave size: **25 invitations**, with at least 48 hours between waves.
+- A wave is released only after the previous wave's error rate and p95 latency
+  have been checked against the CloudWatch alarms in
+  `infra/monitoring/chatbot-alarms.yml`.
+- Wave size may be raised once a concurrency sweep has established a knee that
+  sits comfortably above observed peak concurrency.
+
+Staggering is chosen as the **first** lever, ahead of any capacity
+engineering, for three reasons:
+
+1. It costs nothing. No code, no infrastructure change, no deploy.
+2. It attacks the actual risk. The exposure is a correlated spike, and
+   spreading arrivals is the direct remedy for a correlated spike.
+3. It produces information. Each wave is a graduated load test with real
+   traffic, so peak concurrency becomes an observation rather than an
+   estimate, and the next wave is sized against data.
+
+This is deliberately a process control rather than a technical one. The
+technical levers — ECS task count, `--workers` in the Dockerfile CMD, the
+native async client in issue #52 — all remain available and are not precluded.
+They are simply more expensive and slower than not sending all the email at
+once, and none of them should be sequenced ahead of it.
+
+## Consequences
+
+**The first wave is unmitigated.** All 100 invitations are already delivered.
+This decision cannot be applied retroactively, and the correlated-spike risk
+for that cohort is carried as-is. The compensating measures are monitoring
+rather than prevention:
+
+- The CloudWatch alarms from PR #54 (including the ELB-origin 5xx alarm that
+  catches non-responding targets) are the detection path.
+- If 5xx rates climb, the fastest available response is raising the ECS
+  desired count on the prod service — a console or CLI change requiring no
+  deploy, and the correct first response given that the application, not the
+  infrastructure, is the constraint.
+
+**Onboarding is slower.** Reaching 100 activated users takes roughly four
+waves — about a week longer than a single send. This is accepted. The
+alternative buys speed with the risk of an outage in front of the entire
+evaluation cohort.
+
+**This ADR expires on measurement.** It is a hedge against an unknown ceiling,
+not a permanent policy. Once a sweep establishes where the knee actually is,
+this should be revisited: if the knee is far above realistic peak concurrency,
+the constraint is unnecessary and waves can be collapsed back into a single
+send.
+
+**Latency is untouched by this decision and remains the larger beta risk.**
+Staggering prevents errors. It does nothing about ~13–20s responses, which
+will shape beta feedback more than capacity will at these user counts. That is
+a separate problem and needs its own treatment — streaming partial output or
+visible progress rather than more servers.
+
+## Related
+
+- [ADR 0001](0001-fix-event-loop-blocking-llm-calls.md) — the capacity
+  measurements this decision hedges against
+- Issue #52 — native async Gemini client; raises the per-task ceiling from
+  ~32 in-flight calls, well above beta-scale concurrency
+- `infra/monitoring/chatbot-alarms.yml` — the alarms serving as the detection
+  path for the unmitigated first wave

--- a/docs/adr/0002-stagger-onboarding-waves-during-testing.md
+++ b/docs/adr/0002-stagger-onboarding-waves-during-testing.md
@@ -3,8 +3,23 @@
 ## Status
 
 Accepted (2026-08-16). **Not applied to the first beta wave** — all 100
-invitations had already been sent when this decision was taken. This ADR
-governs subsequent waves.
+invitations had already been sent when this decision was taken.
+
+**Superseded in practice by measurement (2026-08-17).** This ADR's own expiry
+condition was "once a sweep establishes where the knee actually is, this
+should be revisited." That sweep has now run.
+[ADR 0003](0003-native-async-gemini-client.md) records prod handling **256
+concurrent requests with zero errors**, with the knee at concurrency 128 —
+roughly 17–50× the 5–15 concurrent this document estimated for a 100-invite
+spike. The correlated-arrival risk that motivated staggering is no longer a
+capacity risk at beta scale.
+
+Waves remain reasonable for *product* reasons — graduated feedback, support
+load, room to react to bugs — but they are no longer needed to protect
+availability, and wave size should not be constrained by capacity fear. The
+reasoning below is retained because it documents how the decision was made
+under uncertainty, and because the "measure before engineering, stagger while
+unproven" pattern applies again the next time capacity is unknown.
 
 ## Context
 

--- a/docs/adr/0003-native-async-gemini-client.md
+++ b/docs/adr/0003-native-async-gemini-client.md
@@ -2,10 +2,10 @@
 
 ## Status
 
-Proposed (2026-08-17). Implements issue #52. Supersedes the mechanism —
-though not the reasoning — of
+Accepted and verified on dev (2026-08-17). Implements issue #52. Supersedes
+the mechanism — though not the reasoning — of
 [ADR 0001](0001-fix-event-loop-blocking-llm-calls.md) for Gemini calls.
-BigQuery calls keep ADR 0001's treatment unchanged.
+BigQuery calls keep ADR 0001's treatment unchanged. Not yet deployed to prod.
 
 ## Context
 
@@ -85,19 +85,50 @@ no longer exists.
 
 ## Consequences
 
-**Verification is pending.** The dev sweep above is the *before* measurement.
-The same sweep must be re-run against dev after deploy, at the same levels
-(1,4,16,32), and the results recorded here. The hypothesis this ADR rests on
-is falsifiable and should be treated as unproven until then:
+**Verified on dev (same 1-task environment, same levels, 2026-08-17).** The
+stated hypothesis was that the plateau at concurrency 16 should rise and the
+504s at 32 should disappear if the thread pool was the binding constraint. It
+did, and they did:
 
-> If the thread pool was the binding constraint, the plateau at concurrency 16
-> should rise and the 504s at 32 should reduce or disappear. If throughput
-> still peaks near 0.44 rps, the constraint is elsewhere — most likely
-> upstream Gemini rate limits or the single uvicorn worker — and this change
-> is correctness hygiene only.
+| conc | rps before | rps after | p50 before | p50 after | errors before | errors after |
+|------|-----------|-----------|-----------|-----------|---------------|--------------|
+| 1 | 0.08 | 0.04 † | 12.1s | 27.7s † | 0% | 0% |
+| 4 | 0.14 | 0.31 | 11.6s | 11.9s | 0% | 0% |
+| 16 | 0.44 | 0.92 | 29.6s | 12.2s | 0% | 0% |
+| 32 | 0.24 | **1.83** | 42.7s | **13.2s** | **54.7%** | **0%** |
 
-**Cost of measurement is negligible.** The full 106-request sweep cost $0.24,
-so re-running it is not a spend decision.
+† The concurrency-1 row is a cold-start artefact, not a regression. It is two
+requests against a container that had just been replaced, and its `queue*`
+attribution was 18.6s against 0.4s in the before run — the cost of warming,
+not of serving. Every subsequent level settles at ~12–13s p50.
+
+The headline results at concurrency 32: throughput **7.6× higher** (0.24 →
+1.83 rps), p50 **3.2× faster** (42.7s → 13.2s), and **zero errors where 55%
+of requests previously died** as HTTP 504s. Peak measured throughput rose
+4.2× (0.44 → 1.83 rps), and **no saturation knee exists in the tested range**
+any more — throughput was still climbing at the highest level.
+
+The mechanism check confirms the diagnosis rather than merely the outcome.
+Effective in-flight requests, computed as throughput × service time, went from
+0.44 × 12s ≈ **5.3** to 1.83 × 13.2s ≈ **24**. A jump from ~5 to ~24 is
+precisely what removing a ~5-worker thread-pool cap predicts. The constraint
+was the pool, as argued, and not something correlated with it.
+
+Notably, p50 stayed flat (~12–13s) from concurrency 4 to 32 while throughput
+rose 6×. That is the signature of genuine parallelism: added load is absorbed
+rather than queued.
+
+**Cost of measurement is negligible.** The before sweep cost $0.24 and the
+after sweep $0.37 (higher only because zero requests failed, so more real
+answers were generated). Re-running this is not a spend decision.
+
+**The new ceiling is unknown.** The sweep stopped at concurrency 32 because
+that is where the old build collapsed; the new build was still climbing there.
+Where it actually breaks has not been measured, and the same trap that made
+ADR 0001 under-call the thread pool applies here — an untested range is not a
+safe range. A follow-up sweep at 64/128 would locate it. Upstream Gemini
+quota is the most likely next constraint, and unlike task count it cannot be
+scaled around.
 
 **Test doubles had to change shape.** Mocks now have to be awaitable —
 `AsyncMock` on `client.aio.models.generate_content` and on

--- a/docs/adr/0003-native-async-gemini-client.md
+++ b/docs/adr/0003-native-async-gemini-client.md
@@ -1,0 +1,142 @@
+# ADR 0003: Issue Gemini calls through native async clients instead of asyncio.to_thread
+
+## Status
+
+Proposed (2026-08-17). Implements issue #52. Supersedes the mechanism —
+though not the reasoning — of
+[ADR 0001](0001-fix-event-loop-blocking-llm-calls.md) for Gemini calls.
+BigQuery calls keep ADR 0001's treatment unchanged.
+
+## Context
+
+ADR 0001 removed the event-loop-blocking bug by wrapping every synchronous
+`generate_content()` call in `asyncio.to_thread`. That was the right immediate
+fix and it worked, but it was explicitly a workaround: `asyncio.to_thread`
+hands work to Python's default `ThreadPoolExecutor`, which is capped at
+`min(32, cpu_count + 4)` workers.
+
+ADR 0001 recorded that cap as "not a limit at the concurrency levels tested
+(1–8)". A concurrency sweep against dev on 2026-08-16, pushing further than
+ADR 0001 did, found that it becomes the limit well before we expected:
+
+| conc | rps | p50 | p95 | errors |
+|------|------|-------|-------|--------------------|
+| 1 | 0.08 | 12.1s | 15.1s | 0% |
+| 4 | 0.14 | 11.6s | 45.4s | 0% |
+| 16 | **0.44** | 29.6s | 39.4s | 0% |
+| 32 | 0.24 | 42.7s | 59.5s | **54.7%** (35× 504) |
+
+Throughput peaked at concurrency 16 and went *backwards* at 32, which is
+saturation, not headroom. Two details identify the thread pool as the
+constraint:
+
+1. **The arithmetic matches a pool of ~5.** Peak throughput of 0.44 rps
+   against ~12s per call implies roughly 5.3 requests genuinely in flight
+   (0.44 × 12). The dev ECS task is allocated 512 CPU units, so
+   `min(32, cpu_count + 4)` resolves to about 5–6 workers, not 32. The `32`
+   in that formula is a ceiling, not the value — a detail easy to misread,
+   and the reason ADR 0001 under-weighted this risk.
+2. **The failures are queueing, not crashes.** The 35 errors were HTTP 504
+   clustered at a hard 60s boundary (p99 60.2s, max 60.4s) — the ALB idle
+   timeout cutting off requests that were still waiting for a thread.
+
+So the cap ADR 0001 dismissed as distant is roughly six times closer than its
+`32` reading implied, and it is the active ceiling today.
+
+## Decision
+
+Replace `asyncio.to_thread`-wrapped Gemini calls with the SDKs' native async
+entry points, so a call in flight yields the event loop instead of holding a
+thread-pool worker. Two SDKs are in play and get different treatment.
+
+**`google.genai` (v2.6.0) — use `client.aio.models.generate_content`:**
+
+- `agent_v2.py` — the router, refusal, and main generation calls
+- `document_selector.py` — company extraction
+- `financial_utils.py` — the cached-content branch of `parse_user_query`
+
+**`google.generativeai` (v0.8.6, deprecated) — use `generate_content_async`:**
+
+- `financial_utils.py` — the legacy fallback branch of `parse_user_query`,
+  and `format_response`
+
+**Not changed — `asyncio.to_thread` remains correct for BigQuery:**
+`google-cloud-bigquery` has no first-party async client, so `query_data`
+(`main.py`) and the interactions-log insert (`interaction_log.py`) keep
+ADR 0001's treatment. A thread is the right tool when the library has no
+async path; it was only the wrong tool when a native one existed.
+
+### Structural consequences
+
+`extract_companies_from_query` is called from both a synchronous subtree
+(`semantic_document_selection` → `auto_load_relevant_documents`) and the async
+request path. Rather than convert the whole subtree, it is split into a sync
+function and an `extract_companies_from_query_async` variant sharing
+`_build_extraction_request` / `_parse_extraction_response` helpers, so the
+prompt exists in exactly one place.
+
+`FinancialDataManager.parse_user_query` and `.format_response` become genuinely
+`async def`. ADR 0001 deliberately avoided this, on the grounds that they were
+called synchronously elsewhere. That reasoning no longer holds: the only live
+synchronous callers were tests. `app/_archive/streaming_financial_chat.py`
+still calls them synchronously but is not imported by the running application
+(see `_archive/README.md`), and its own tests already import a module path that
+no longer exists.
+
+## Consequences
+
+**Verification is pending.** The dev sweep above is the *before* measurement.
+The same sweep must be re-run against dev after deploy, at the same levels
+(1,4,16,32), and the results recorded here. The hypothesis this ADR rests on
+is falsifiable and should be treated as unproven until then:
+
+> If the thread pool was the binding constraint, the plateau at concurrency 16
+> should rise and the 504s at 32 should reduce or disappear. If throughput
+> still peaks near 0.44 rps, the constraint is elsewhere — most likely
+> upstream Gemini rate limits or the single uvicorn worker — and this change
+> is correctness hygiene only.
+
+**Cost of measurement is negligible.** The full 106-request sweep cost $0.24,
+so re-running it is not a spend decision.
+
+**Test doubles had to change shape.** Mocks now have to be awaitable —
+`AsyncMock` on `client.aio.models.generate_content` and on
+`model.generate_content_async`. A regression back to blocking calls would
+leave those mocks un-awaited and fail loudly, which is the intended tripwire.
+
+**The deprecated SDK is still on the critical path.** `financial_utils.py`
+continues to import `google.generativeai`, which has ended all support and
+emits a deprecation warning on import. `generate_content_async` narrows the
+damage but does not remove the dependency. Migrating that module onto
+`google.genai` is deliberately out of scope here and warrants its own issue.
+
+**Known gaps carried forward from ADR 0001, still unaddressed:**
+
+- The `ai_request_duration_seconds` histogram still reads 0ms, so the load
+  test's attribution table cannot split Gemini time from app time. All 45s of
+  server time at concurrency 32 landed in "other". The diagnosis above rests
+  on wall-clock, throughput and a code read — not on that metric.
+- Neither uvicorn `--workers` nor ECS task count is changed here. If the
+  re-run shows the ceiling moved but is still too low, those are the next
+  levers, in that order.
+- The 60s ALB idle timeout is what converts saturation into 504s. Raising it
+  would turn fast failures into slow ones, which is not obviously better, but
+  it should be a deliberate choice rather than an inherited default.
+
+## How to reproduce this measurement
+
+```bash
+python loadtest/loadtest.py --base-url <dev-url> --endpoint health --levels 1,4,16,32
+python loadtest/loadtest.py --base-url <dev-url> --endpoint chat_stream --levels 1,4,16,32 --max-cost-usd 10.00
+```
+
+## Related
+
+- [ADR 0001](0001-fix-event-loop-blocking-llm-calls.md) — the `asyncio.to_thread`
+  fix this supersedes for Gemini calls
+- [ADR 0002](0002-stagger-onboarding-waves-during-testing.md) — the onboarding
+  hedge taken while this ceiling was unknown
+- Issue #52 — the change implemented here
+- Issue #51 — `/fast_chat_v2` cost/cache reporting in `loadtest.py` is broken,
+  so that endpoint's cost numbers are untrustworthy (latency/throughput/errors
+  are fine)

--- a/docs/adr/0003-native-async-gemini-client.md
+++ b/docs/adr/0003-native-async-gemini-client.md
@@ -2,10 +2,10 @@
 
 ## Status
 
-Accepted and verified on dev (2026-08-17). Implements issue #52. Supersedes
-the mechanism — though not the reasoning — of
+Accepted, verified on dev, and deployed and re-verified on prod (2026-08-17).
+Implements issue #52. Supersedes the mechanism — though not the reasoning — of
 [ADR 0001](0001-fix-event-loop-blocking-llm-calls.md) for Gemini calls.
-BigQuery calls keep ADR 0001's treatment unchanged. Not yet deployed to prod.
+BigQuery calls keep ADR 0001's treatment unchanged.
 
 ## Context
 
@@ -154,11 +154,53 @@ The concurrency-32 row also reproduces the previous sweep (1.69 vs 1.83 rps,
 about 8% run-to-run variance), which is worth knowing before reading small
 differences in any future comparison as signal.
 
-**What has not been identified is *which* limit this is.** Candidates are the
-single uvicorn worker, the event loop itself, and upstream Gemini quota. The
-distinction matters, because the first two are scaled around with `--workers`
-or task count while quota is not. The broken `ai_request_duration_seconds`
-metric is what prevents settling this from the existing data.
+**Prod (2 tasks × 1024 CPU) re-verified after deploy, 2026-08-17.** 1002 paid
+requests across six concurrency levels:
+
+| conc | rps | p50 | p95 | errors |
+|------|------|-------|-------|--------|
+| 1 | 0.09 | 11.5s | 12.1s | 0% |
+| 4 | 0.27 | 13.0s | 18.8s | 0% |
+| 16 | 0.96 | 12.2s | 18.3s | 0% |
+| 32 | 1.75 | 13.5s | 20.8s | 0% |
+| 64 | 2.43 | 15.4s | 24.9s | 0% |
+| 128 | **4.89** | 16.5s | 28.0s | 0% |
+| 256 | 5.48 | 25.2s | 40.7s | 0% |
+
+**Zero errors at every level, including 256 concurrent.** For scale, ADR 0001
+recorded prod losing 17 requests to HTTP 504 at concurrency *8* before that
+fix; concurrency 256 now completes cleanly. No CloudWatch alarm changed state
+during the sweep — including `prod-gemini-quota-exhausted` and the
+ELB-origin 5xx alarm added in PR #54 — and both ECS tasks stayed up with no
+restarts.
+
+Prod's knee is at concurrency **128**, peaking near **5.5 rps**: 64→128 scaled
+at essentially 100% efficiency (2.43 → 4.89 rps), while 128→256 returned only
+12% more throughput for double the load, with `queue*` rising 1740ms → 4563ms.
+
+### The scaling result is the actionable finding
+
+Prod has **4× dev's total CPU** (2 × 1024 units vs 1 × 512) but delivers only
+**1.5× the throughput** (5.48 vs 3.69 rps). Throughput tracks *task count*
+(2× tasks → 1.5× throughput) far better than it tracks CPU, and the extra 512
+CPU units per task bought close to nothing.
+
+That is the signature of an **I/O-bound workload**, which is what this is: the
+request is dominated by waiting on a network call to Gemini, not by local
+computation. The consequence for capacity planning is concrete and slightly
+counterintuitive:
+
+> **Scale out, not up.** Raising `cpu`/`memory` on the task is close to wasted
+> spend. Adding ECS tasks — or uvicorn `--workers`, which adds event loops
+> within a task — is the lever that moves throughput.
+
+This also revises the guess in the dev section above. CPU is ruled out. The
+remaining candidates are the per-process event loop and upstream Gemini
+quota, and the sublinearity (2× tasks buying 1.5×, not 2×) hints at a shared
+constraint starting to bind. The `gemini-quota-exhausted` alarm staying OK is
+weak evidence against quota, but that alarm's threshold has not been checked
+against these rates, so it is not conclusive. The broken
+`ai_request_duration_seconds` metric remains what prevents settling this.
 
 **Test doubles had to change shape.** Mocks now have to be awaitable —
 `AsyncMock` on `client.aio.models.generate_content` and on

--- a/docs/adr/0003-native-async-gemini-client.md
+++ b/docs/adr/0003-native-async-gemini-client.md
@@ -122,13 +122,43 @@ rather than queued.
 after sweep $0.37 (higher only because zero requests failed, so more real
 answers were generated). Re-running this is not a spend decision.
 
-**The new ceiling is unknown.** The sweep stopped at concurrency 32 because
-that is where the old build collapsed; the new build was still climbing there.
-Where it actually breaks has not been measured, and the same trap that made
-ADR 0001 under-call the thread pool applies here — an untested range is not a
-safe range. A follow-up sweep at 64/128 would locate it. Upstream Gemini
-quota is the most likely next constraint, and unlike task count it cannot be
-scaled around.
+**The new ceiling is soft, and sits near concurrency 128 on a single task.**
+A follow-up sweep pushed further (2026-08-17, same 1-task dev environment):
+
+| conc | rps | p50 | p95 | errors | scaling efficiency |
+|------|------|-------|-------|--------|--------------------|
+| 32 | 1.69 | 13.6s | 23.4s | 0% | — |
+| 64 | 2.94 | 14.2s | 24.1s | 0% | 87% |
+| 128 | 3.69 | 17.6s | 30.2s | 0.4% (1×504) | **63%** |
+
+There is no collapse anywhere in this range — a meaningful contrast with the
+pre-change build, which lost 55% of requests at concurrency 32. But the
+ceiling is visible as deceleration rather than a cliff. Doubling concurrency
+from 32 to 64 bought 1.74× throughput (87% efficient); doubling again to 128
+bought only 1.26× (63% efficient). Three independent signals agree that
+saturation is beginning around 128:
+
+1. **Throughput is flattening** toward roughly 4 rps per task.
+2. **Queueing has appeared.** The `queue*` attribution held flat at ~890ms
+   through concurrency 64, then rose to 2172ms at 128 — the first evidence of
+   requests waiting to be picked up rather than being served immediately.
+3. **The first timeout returned.** One HTTP 504, with a max latency of 54.1s,
+   approaching the 60s ALB idle timeout that converted saturation into mass
+   failure in the pre-change build.
+
+Effective in-flight requests at concurrency 128 is 3.69 × 17.6s ≈ **65**, not
+128 — so roughly half the offered load is queueing. That is the mechanism
+behind the deceleration.
+
+The concurrency-32 row also reproduces the previous sweep (1.69 vs 1.83 rps,
+about 8% run-to-run variance), which is worth knowing before reading small
+differences in any future comparison as signal.
+
+**What has not been identified is *which* limit this is.** Candidates are the
+single uvicorn worker, the event loop itself, and upstream Gemini quota. The
+distinction matters, because the first two are scaled around with `--workers`
+or task count while quota is not. The broken `ai_request_duration_seconds`
+metric is what prevents settling this from the existing data.
 
 **Test doubles had to change shape.** Mocks now have to be awaitable —
 `AsyncMock` on `client.aio.models.generate_content` and on

--- a/fastapi_app/app/agent_v2.py
+++ b/fastapi_app/app/agent_v2.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional
 
 from google.genai import types
 
-from app.document_selector import extract_companies_from_query
+from app.document_selector import extract_companies_from_query_async
 from app.gemini_client import get_genai_client
 from app.logging_config import get_logger
 from app.models import CostSummary, PhaseCost
@@ -342,7 +342,8 @@ class AgentV2:
         auto-loading (app.document_selector.extract_companies_from_query) —
         an LLM call that understands context, so it doesn't mistake a metric
         abbreviation (e.g. "ROC" meaning Return on Capital) for a ticker
-        mention. Runs in a thread so it can overlap with the router call.
+        mention. Issued through the SDK's native async client so it can
+        overlap with the router call without occupying a thread-pool worker.
         """
         if financial_manager is None or not getattr(financial_manager, "metadata", None):
             return []
@@ -351,8 +352,8 @@ class AgentV2:
         symbols = metadata.get("symbols") or []
         if not symbols:
             return []
-        extracted = await asyncio.to_thread(
-            extract_companies_from_query, query, companies, symbols, conversation_history
+        extracted = await extract_companies_from_query_async(
+            query, companies, symbols, conversation_history
         )
         return extracted.get("symbols") or []
 
@@ -411,10 +412,10 @@ class AgentV2:
             contents = self._build_contents(conversation_history, query)
 
             # Step 1 — ROUTE: plain-text 2-way classify (no tools, no grounding).
-            # Runs in a thread — generate_content is a blocking call, and this
-            # method runs inside the app's single event loop (see loadtest/README.md).
-            route = await asyncio.to_thread(
-                self.client.models.generate_content,
+            # Uses the SDK's native async client so the call yields the event
+            # loop directly, without occupying a thread-pool worker
+            # (see docs/adr/0003-native-async-gemini-client.md).
+            route = await self.client.aio.models.generate_content(
                 model=ROUTER_MODEL,
                 contents=contents,
                 config=types.GenerateContentConfig(
@@ -435,8 +436,7 @@ class AgentV2:
                 return None
 
             # --- REFUSE: Flash answers directly, no Pro call needed ---
-            refusal = await asyncio.to_thread(
-                self.client.models.generate_content,
+            refusal = await self.client.aio.models.generate_content(
                 model=ROUTER_MODEL,
                 contents=contents,
                 config=types.GenerateContentConfig(
@@ -541,11 +541,11 @@ class AgentV2:
             tools = [types.Tool(google_search=types.GoogleSearch())] if enable_web_search else None
             system_prompt = SYSTEM_PROMPT if enable_web_search else SYSTEM_PROMPT_NO_SEARCH
 
-            # Single generate_content call with optional grounding, run in a
-            # thread so it doesn't block the event loop (see loadtest/README.md).
+            # Single generate_content call with optional grounding, issued
+            # through the SDK's native async client so it yields the event loop
+            # (see docs/adr/0003-native-async-gemini-client.md).
             _cache = _SYSTEM_PROMPT_CACHE if enable_web_search else _SYSTEM_PROMPT_NO_SEARCH_CACHE
-            response = await asyncio.to_thread(
-                self.client.models.generate_content,
+            response = await self.client.aio.models.generate_content(
                 model=self.model_name,
                 contents=contents,
                 config=self._make_config(

--- a/fastapi_app/app/document_selector.py
+++ b/fastapi_app/app/document_selector.py
@@ -30,46 +30,33 @@ logger = get_logger(__name__)
 # =============================================================================
 
 
-def extract_companies_from_query(
+def _build_extraction_request(
     query: str,
     available_companies: List[str],
     available_symbols: Optional[List[str]] = None,
     conversation_history: Optional[List] = None,
-) -> Dict:
+) -> tuple:
+    """Build the (model_name, contents, config) triple for company extraction.
+
+    Shared by the sync and async variants of extract_companies_from_query so
+    the prompt only exists in one place.
     """
-    Use fast LLM to extract company names/symbols from user query.
+    model_name = "gemini-2.5-flash"  # Fast model for simple extraction
 
-    This is Stage 1 of the two-stage document selection approach.
-    Uses a smaller, faster model (gemini-2.5-flash) for simple entity extraction.
+    # Format conversation history if available
+    conversation_context = ""
+    if conversation_history and len(conversation_history) > 0:
+        recent_history = conversation_history[-6:]  # Last 3 exchanges
+        conversation_context = "\n".join(
+            [f"{msg['role']}: {msg['content']}" for msg in recent_history]
+        )
 
-    Args:
-        query: User query
-        available_companies: List of valid company names from metadata
-        available_symbols: Optional list of valid trading symbols
-        conversation_history: Optional conversation context
+    # Build a concise prompt with just company/symbol lists
+    symbols_section = ""
+    if available_symbols:
+        symbols_section = f"Available trading symbols: {', '.join(available_symbols)}"
 
-    Returns:
-        Dict with companies and symbols mentioned
-    """
-    start_time = time.time()
-    try:
-        client = get_genai_client()
-        model_name = "gemini-2.5-flash"  # Fast model for simple extraction
-
-        # Format conversation history if available
-        conversation_context = ""
-        if conversation_history and len(conversation_history) > 0:
-            recent_history = conversation_history[-6:]  # Last 3 exchanges
-            conversation_context = "\n".join(
-                [f"{msg['role']}: {msg['content']}" for msg in recent_history]
-            )
-
-        # Build a concise prompt with just company/symbol lists
-        symbols_section = ""
-        if available_symbols:
-            symbols_section = f"Available trading symbols: {', '.join(available_symbols)}"
-
-        prompt = f"""Extract company names and trading symbols mentioned in the user query.
+    prompt = f"""Extract company names and trading symbols mentioned in the user query.
 
 Available companies:
 {', '.join(available_companies)}
@@ -91,52 +78,126 @@ Return ONLY valid JSON in this format:
 {{"companies": ["company1", "company2"], "symbols": ["SYM1", "SYM2"]}}
 """
 
-        # Build content for the SDK
-        contents = [types.Content(role="user", parts=[types.Part.from_text(text=prompt)])]
+    # Build content for the SDK
+    contents = [types.Content(role="user", parts=[types.Part.from_text(text=prompt)])]
 
-        # Use low temperature for deterministic extraction
-        generate_config = types.GenerateContentConfig(
-            temperature=0.1,
-            max_output_tokens=512,
+    # Use low temperature for deterministic extraction
+    generate_config = types.GenerateContentConfig(
+        temperature=0.1,
+        max_output_tokens=512,
+    )
+
+    return model_name, contents, generate_config
+
+
+def _parse_extraction_response(response_text: str, start_time: float) -> Dict:
+    """Strip any markdown fence, isolate the JSON object, and parse it.
+
+    Shared by the sync and async variants of extract_companies_from_query.
+    """
+    clean_text = response_text.strip()
+    if clean_text.startswith("```"):
+        first_newline = clean_text.find("\n")
+        if first_newline != -1:
+            clean_text = clean_text[first_newline + 1 :]
+        if clean_text.endswith("```"):
+            clean_text = clean_text[:-3].strip()
+
+    json_start = clean_text.find("{")
+    json_end = clean_text.rfind("}") + 1
+    if json_start >= 0 and json_end > json_start:
+        clean_text = clean_text[json_start:json_end]
+
+    result = json.loads(clean_text)
+
+    duration = time.time() - start_time
+    logger.info(
+        f"Company extraction completed in {duration:.2f}s: "
+        f"companies={result.get('companies', [])}, symbols={result.get('symbols', [])}"
+    )
+
+    return result
+
+
+def _log_extraction_failure(exc: Exception, query: str) -> Dict:
+    """Log an extraction failure and return the empty result both variants use."""
+    logger.error(
+        "company_extraction_failed",
+        extra={"error": str(exc), "error_type": type(exc).__name__, "query": query[:100]},
+    )
+    return {"companies": [], "symbols": []}
+
+
+def extract_companies_from_query(
+    query: str,
+    available_companies: List[str],
+    available_symbols: Optional[List[str]] = None,
+    conversation_history: Optional[List] = None,
+) -> Dict:
+    """
+    Use fast LLM to extract company names/symbols from user query.
+
+    This is Stage 1 of the two-stage document selection approach.
+    Uses a smaller, faster model (gemini-2.5-flash) for simple entity extraction.
+
+    Synchronous variant, kept for the synchronous document-selection subtree
+    (semantic_document_selection -> auto_load_relevant_documents). Async
+    callers on the request path should use extract_companies_from_query_async
+    instead, which avoids occupying a thread-pool worker.
+
+    Args:
+        query: User query
+        available_companies: List of valid company names from metadata
+        available_symbols: Optional list of valid trading symbols
+        conversation_history: Optional conversation context
+
+    Returns:
+        Dict with companies and symbols mentioned
+    """
+    start_time = time.time()
+    try:
+        client = get_genai_client()
+        model_name, contents, generate_config = _build_extraction_request(
+            query, available_companies, available_symbols, conversation_history
         )
-
         response = client.models.generate_content(
             model=model_name,
             contents=contents,
             config=generate_config,
         )
-        response_text = response.text.strip()
-
-        # Parse JSON response
-        clean_text = response_text
-        if clean_text.startswith("```"):
-            first_newline = clean_text.find("\n")
-            if first_newline != -1:
-                clean_text = clean_text[first_newline + 1 :]
-            if clean_text.endswith("```"):
-                clean_text = clean_text[:-3].strip()
-
-        json_start = clean_text.find("{")
-        json_end = clean_text.rfind("}") + 1
-        if json_start >= 0 and json_end > json_start:
-            clean_text = clean_text[json_start:json_end]
-
-        result = json.loads(clean_text)
-
-        duration = time.time() - start_time
-        logger.info(
-            f"Company extraction completed in {duration:.2f}s: "
-            f"companies={result.get('companies', [])}, symbols={result.get('symbols', [])}"
-        )
-
-        return result
+        return _parse_extraction_response(response.text, start_time)
 
     except Exception as e:
-        logger.error(
-            "company_extraction_failed",
-            extra={"error": str(e), "error_type": type(e).__name__, "query": query[:100]},
+        return _log_extraction_failure(e, query)
+
+
+async def extract_companies_from_query_async(
+    query: str,
+    available_companies: List[str],
+    available_symbols: Optional[List[str]] = None,
+    conversation_history: Optional[List] = None,
+) -> Dict:
+    """Async variant of extract_companies_from_query.
+
+    Identical behaviour and prompt, issued through the SDK's native async
+    client so the call yields the event loop instead of occupying a
+    thread-pool worker (see docs/adr/0003-native-async-gemini-client.md).
+    """
+    start_time = time.time()
+    try:
+        client = get_genai_client()
+        model_name, contents, generate_config = _build_extraction_request(
+            query, available_companies, available_symbols, conversation_history
         )
-        return {"companies": [], "symbols": []}
+        response = await client.aio.models.generate_content(
+            model=model_name,
+            contents=contents,
+            config=generate_config,
+        )
+        return _parse_extraction_response(response.text, start_time)
+
+    except Exception as e:
+        return _log_extraction_failure(e, query)
 
 
 def resolve_companies(

--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -515,14 +515,19 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
             logger.error(f"DSPy query parsing error: {e}")
             return None
 
-    def parse_user_query(
+    async def parse_user_query(
         self,
         query: str,
         conversation_history: Optional[List[Dict[str, str]]] = None,
         last_query_data: Optional[Dict] = None,
         cost_sink: Optional[List[CostResult]] = None,
     ) -> FinancialDataFilters:
-        """Use DSPy or Gemini to parse user query and extract filter parameters with conversation context"""
+        """Use DSPy or Gemini to parse user query and extract filter parameters with conversation context
+
+        Async because the Gemini calls below are issued through native async
+        clients, so they yield the event loop rather than occupying a
+        thread-pool worker (see docs/adr/0003-native-async-gemini-client.md).
+        """
 
         # Try DSPy first if enabled
         if self.use_dspy and self.dspy_query_parser:
@@ -555,7 +560,7 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
                 if cache_name:
                     try:
                         client = get_genai_client()
-                        response = client.models.generate_content(
+                        response = await client.aio.models.generate_content(
                             model=model_name,
                             contents=[
                                 genai_types.Content(
@@ -571,9 +576,12 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
                             extra={"error": str(cache_exc)},
                         )
                 if not response:
-                    # Fallback: combine into one prompt and use the legacy model
+                    # Fallback: combine into one prompt and use the legacy model.
+                    # generate_content_async is the deprecated google.generativeai
+                    # package's async entry point — still the right call here
+                    # until this path migrates onto google.genai (see ADR 0003).
                     prompt = f"{system_instruction}\n\n{dynamic_content}"
-                    response = self.model.generate_content(prompt)
+                    response = await self.model.generate_content_async(prompt)
                 response_text = response.text.strip()
                 duration = time.time() - start_time
 
@@ -1205,7 +1213,7 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
             logger.error(f"DSPy response formatting error: {e}")
             return None
 
-    def format_response(
+    async def format_response(
         self,
         records: List[FinancialDataRecord],
         query: str,
@@ -1215,7 +1223,12 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
         unrecognized_items: Optional[List[str]] = None,
         cost_sink: Optional[List[CostResult]] = None,
     ) -> str:
-        """Format the query results into a readable response with conversation awareness"""
+        """Format the query results into a readable response with conversation awareness
+
+        Async for the same reason as parse_user_query — the Gemini call is
+        issued through a native async client rather than a thread
+        (see docs/adr/0003-native-async-gemini-client.md).
+        """
 
         # Detect if we should recommend Deep Research
         should_recommend_deep_research = self._should_recommend_deep_research(
@@ -1310,7 +1323,9 @@ Do NOT provide any analysis, data, or commentary regarding share prices, dividen
             with traced_observation(
                 "format_response", as_type="generation", model=model_name, input=prompt
             ) as gen:
-                response = self.model.generate_content(prompt)
+                # Deprecated google.generativeai async entry point; see the note
+                # in parse_user_query and ADR 0003's follow-up.
+                response = await self.model.generate_content_async(prompt)
                 duration = time.time() - start_time
                 cost_result = calculate_cost_from_response(
                     model_name, response, phase="format_response"

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -645,13 +645,14 @@ async def fast_chat_v2(
         with traced_observation(
             "fast_chat_v2", as_type="span", input={"query": request.query}
         ) as trace_obs:
-            # parse_user_query/query_data/format_response are synchronous
-            # (Gemini + BigQuery calls) and this endpoint runs on the app's
-            # single event loop — run each in a thread so it doesn't block
-            # every other in-flight request (see loadtest/README.md and ADR
-            # docs/adr/0001-fix-event-loop-blocking-llm-calls.md).
-            filters = await asyncio.to_thread(
-                financial_manager.parse_user_query,
+            # parse_user_query/format_response are now genuinely async and
+            # issue their Gemini calls through native async clients, so they
+            # yield the event loop without occupying a thread-pool worker
+            # (docs/adr/0003-native-async-gemini-client.md). query_data stays
+            # wrapped in asyncio.to_thread — google-cloud-bigquery has no
+            # first-party async client, so a thread is still the right tool
+            # there (docs/adr/0001-fix-event-loop-blocking-llm-calls.md).
+            filters = await financial_manager.parse_user_query(
                 request.query,
                 request.conversation_history,
                 last_query_data,
@@ -665,8 +666,7 @@ async def fast_chat_v2(
             suggestions = availability.get("suggestions", [])
             results = await asyncio.to_thread(financial_manager.query_data, filters)
             logger.info(f"results type: {type(results)}, results: {results}")
-            ai_response = await asyncio.to_thread(
-                financial_manager.format_response,
+            ai_response = await financial_manager.format_response(
                 results,
                 request.query,
                 filters.interpretation,

--- a/fastapi_app/tests/test_agent_v2_grounding.py
+++ b/fastapi_app/tests/test_agent_v2_grounding.py
@@ -19,7 +19,7 @@ that was already loaded at startup.
 """
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -30,6 +30,10 @@ from app.agent_v2 import AgentV2
 def mock_genai_client():
     with patch("app.agent_v2.get_genai_client") as mock_get_client:
         mock_client = MagicMock()
+        # AgentV2 calls the SDK's native async client (client.aio.models.
+        # generate_content), so this leaf has to be awaitable — a plain
+        # MagicMock would return a non-awaitable and fail at the await.
+        mock_client.aio.models.generate_content = AsyncMock()
         mock_get_client.return_value = mock_client
         yield mock_client
 
@@ -134,7 +138,7 @@ def test_grounding_note_lists_multiple_companies_if_genuinely_shared():
 
 
 def test_run_injects_grounding_note_into_pro_call(mock_genai_client):
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("ALLOW"),
         _text_response("Medical Disposables & Supplies reported J$3.88 billion."),
     ]
@@ -144,7 +148,7 @@ def test_run_injects_grounding_note_into_pro_call(mock_genai_client):
             "MAILPAC": ["Mailpac Group Limited"],
         }
     )
-    with patch("app.agent_v2.extract_companies_from_query") as mock_extract:
+    with patch("app.agent_v2.extract_companies_from_query_async") as mock_extract:
         mock_extract.return_value = {
             "companies": ["Medical Disposables & Supplies Limited"],
             "symbols": ["MDS"],
@@ -155,7 +159,7 @@ def test_run_injects_grounding_note_into_pro_call(mock_genai_client):
         )
 
     assert result["response"] == "Medical Disposables & Supplies reported J$3.88 billion."
-    calls = mock_genai_client.models.generate_content.call_args_list
+    calls = mock_genai_client.aio.models.generate_content.call_args_list
     assert len(calls) == 2
     pro_contents = calls[1].kwargs["contents"]
     last_turn_parts = pro_contents[-1].parts
@@ -165,33 +169,33 @@ def test_run_injects_grounding_note_into_pro_call(mock_genai_client):
 
 
 def test_run_no_grounding_note_without_financial_manager(mock_genai_client):
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("ALLOW"),
         _text_response("answer"),
     ]
-    with patch("app.agent_v2.extract_companies_from_query") as mock_extract:
+    with patch("app.agent_v2.extract_companies_from_query_async") as mock_extract:
         agent = AgentV2()
         asyncio.run(agent.run(query="What was NCB revenue in 2023?"))
         mock_extract.assert_not_called()
 
-    calls = mock_genai_client.models.generate_content.call_args_list
+    calls = mock_genai_client.aio.models.generate_content.call_args_list
     pro_contents = calls[1].kwargs["contents"]
     assert len(pro_contents[-1].parts) == 1
     assert pro_contents[-1].parts[0].text == "What was NCB revenue in 2023?"
 
 
 def test_run_no_grounding_note_when_extraction_finds_nothing(mock_genai_client):
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("ALLOW"),
         _text_response("answer"),
     ]
     fm = _financial_manager({"MDS": ["Medical Disposables & Supplies Limited"]})
-    with patch("app.agent_v2.extract_companies_from_query") as mock_extract:
+    with patch("app.agent_v2.extract_companies_from_query_async") as mock_extract:
         mock_extract.return_value = {"companies": [], "symbols": []}
         agent = AgentV2()
         asyncio.run(agent.run(query="How is the Jamaican economy doing?", financial_manager=fm))
 
-    calls = mock_genai_client.models.generate_content.call_args_list
+    calls = mock_genai_client.aio.models.generate_content.call_args_list
     pro_contents = calls[1].kwargs["contents"]
     assert len(pro_contents[-1].parts) == 1
 
@@ -199,12 +203,12 @@ def test_run_no_grounding_note_when_extraction_finds_nothing(mock_genai_client):
 def test_run_refuse_path_unaffected_by_grounding(mock_genai_client):
     """REFUSE still short-circuits to 2 Flash calls; extraction (if it ever
     resolves) must not force an extra Pro call or change the refusal text."""
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("REFUSE"),
         _text_response("Sorry, I can only help with JSE topics."),
     ]
     fm = _financial_manager({"MDS": ["Medical Disposables & Supplies Limited"]})
-    with patch("app.agent_v2.extract_companies_from_query") as mock_extract:
+    with patch("app.agent_v2.extract_companies_from_query_async") as mock_extract:
         mock_extract.return_value = {
             "companies": ["Medical Disposables & Supplies Limited"],
             "symbols": ["MDS"],
@@ -213,5 +217,5 @@ def test_run_refuse_path_unaffected_by_grounding(mock_genai_client):
         result = asyncio.run(agent.run(query="Write me a poem about MDS.", financial_manager=fm))
 
     assert result["response"] == "Sorry, I can only help with JSE topics."
-    calls = mock_genai_client.models.generate_content.call_args_list
+    calls = mock_genai_client.aio.models.generate_content.call_args_list
     assert len(calls) == 2

--- a/fastapi_app/tests/test_agent_v2_router.py
+++ b/fastapi_app/tests/test_agent_v2_router.py
@@ -11,7 +11,7 @@ removed.
 """
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -22,6 +22,10 @@ from app.agent_v2 import ROUTER_MODEL, AgentV2
 def mock_genai_client():
     with patch("app.agent_v2.get_genai_client") as mock_get_client:
         mock_client = MagicMock()
+        # AgentV2 calls the SDK's native async client (client.aio.models.
+        # generate_content), so this leaf has to be awaitable — a plain
+        # MagicMock would return a non-awaitable and fail at the await.
+        mock_client.aio.models.generate_content = AsyncMock()
         mock_get_client.return_value = mock_client
         yield mock_client
 
@@ -55,7 +59,7 @@ def _text_response(text):
 
 def test_route_allow_falls_through_to_web(mock_genai_client):
     # route=ALLOW -> no refusal call; web path runs (route + web = 2 calls).
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("ALLOW"),
         _text_response("NCB's 2023 revenue was J$123.5M, per public filings."),
     ]
@@ -64,19 +68,19 @@ def test_route_allow_falls_through_to_web(mock_genai_client):
 
     assert result["response"] == "NCB's 2023 revenue was J$123.5M, per public filings."
     assert "query_financial_data" not in (result.get("tools_executed") or [])
-    assert mock_genai_client.models.generate_content.call_count == 2
+    assert mock_genai_client.aio.models.generate_content.call_count == 2
 
 
 def test_route_call_uses_flash_and_no_tools(mock_genai_client):
     # The ROUTE call is a plain-text flash classification — no tools attached.
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("ALLOW"),
         _text_response("answer"),
     ]
     agent = AgentV2()
     asyncio.run(agent.run(query="NCB revenue 2023?"))
 
-    calls = mock_genai_client.models.generate_content.call_args_list
+    calls = mock_genai_client.aio.models.generate_content.call_args_list
     assert len(calls) == 2
     route_cfg = calls[0].kwargs["config"]
     assert calls[0].kwargs["model"] == "gemini-2.5-flash"
@@ -86,7 +90,7 @@ def test_route_call_uses_flash_and_no_tools(mock_genai_client):
 def test_router_error_falls_through_to_web(mock_genai_client):
     # If the ROUTE call itself raises, _fast_path swallows it and run() still
     # reaches the web/plain path (graceful degradation).
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         RuntimeError("router exploded"),
         _text_response("web fallback answer"),
     ]
@@ -94,7 +98,7 @@ def test_router_error_falls_through_to_web(mock_genai_client):
     result = asyncio.run(agent.run(query="What was NCB revenue in 2023?"))
 
     assert result["response"] == "web fallback answer"
-    assert mock_genai_client.models.generate_content.call_count == 2
+    assert mock_genai_client.aio.models.generate_content.call_count == 2
 
 
 def test_run_uses_cached_content_when_cache_hits(mock_genai_client):
@@ -103,7 +107,7 @@ def test_run_uses_cached_content_when_cache_hits(mock_genai_client):
     resp.text = "hello"
     resp.candidates = []
     resp.usage_metadata = None
-    mock_genai_client.models.generate_content.return_value = resp
+    mock_genai_client.aio.models.generate_content.return_value = resp
 
     with (
         patch("app.agent_v2._SYSTEM_PROMPT_CACHE") as mock_cache,
@@ -114,7 +118,7 @@ def test_run_uses_cached_content_when_cache_hits(mock_genai_client):
         agent = AgentV2()
         asyncio.run(agent.run("What is the JSE?", enable_web_search=True))
 
-    config = mock_genai_client.models.generate_content.call_args.kwargs["config"]
+    config = mock_genai_client.aio.models.generate_content.call_args.kwargs["config"]
     assert config.cached_content == "cachedContents/xyz"
     # system_instruction must be absent (None or not set) when cached_content is used
     assert not getattr(config, "system_instruction", None)
@@ -126,7 +130,7 @@ def test_run_falls_back_to_system_instruction_when_cache_returns_none(mock_genai
     resp.text = "hello"
     resp.candidates = []
     resp.usage_metadata = None
-    mock_genai_client.models.generate_content.return_value = resp
+    mock_genai_client.aio.models.generate_content.return_value = resp
 
     with (
         patch("app.agent_v2._SYSTEM_PROMPT_CACHE") as mock_cache,
@@ -137,7 +141,7 @@ def test_run_falls_back_to_system_instruction_when_cache_returns_none(mock_genai
         agent = AgentV2()
         asyncio.run(agent.run("What is the JSE?", enable_web_search=True))
 
-    config = mock_genai_client.models.generate_content.call_args.kwargs["config"]
+    config = mock_genai_client.aio.models.generate_content.call_args.kwargs["config"]
     assert config.system_instruction is not None
     assert not getattr(config, "cached_content", None)
 
@@ -149,7 +153,7 @@ def test_run_falls_back_to_system_instruction_when_cache_returns_none(mock_genai
 
 def test_refuse_path_uses_flash_only_no_pro(mock_genai_client):
     """REFUSE route: 2 Flash calls (route + refusal), zero Pro calls."""
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("REFUSE"),
         _text_response("Sorry, I can only help with JSE topics."),
     ]
@@ -160,21 +164,21 @@ def test_refuse_path_uses_flash_only_no_pro(mock_genai_client):
     assert result["record_count"] == 0
     assert result["data_found"] is False
     # Both calls must use Flash, not Pro
-    calls = mock_genai_client.models.generate_content.call_args_list
+    calls = mock_genai_client.aio.models.generate_content.call_args_list
     assert len(calls) == 2
     assert all(c.kwargs["model"] == "gemini-2.5-flash" for c in calls)
 
 
 def test_refuse_path_no_tools_on_refusal_call(mock_genai_client):
     """The refusal Flash call must have no tools attached (no grounding)."""
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("REFUSE"),
         _text_response("I can only help with JSE-related topics."),
     ]
     agent = AgentV2()
     asyncio.run(agent.run(query="What is bitcoin?"))
 
-    calls = mock_genai_client.models.generate_content.call_args_list
+    calls = mock_genai_client.aio.models.generate_content.call_args_list
     # calls[0] = route call, calls[1] = refusal generation call
     refusal_cfg = calls[1].kwargs["config"]
     assert refusal_cfg.tools is None
@@ -182,7 +186,7 @@ def test_refuse_path_no_tools_on_refusal_call(mock_genai_client):
 
 def test_refuse_path_conversation_history_none(mock_genai_client):
     """REFUSE path correctly handles conversation_history=None (no crash, history built fresh)."""
-    mock_genai_client.models.generate_content.side_effect = [
+    mock_genai_client.aio.models.generate_content.side_effect = [
         _route_response("REFUSE"),
         _text_response("JSE topics only."),
     ]

--- a/fastapi_app/tests/test_financial_utils.py
+++ b/fastapi_app/tests/test_financial_utils.py
@@ -678,9 +678,7 @@ def test_build_parse_query_system_instruction_contains_metadata():
 
 def test_parse_user_query_uses_cached_content_when_available():
     """parse_user_query passes cached_content= to generate_content when cache hits."""
-    from unittest.mock import MagicMock, patch
-
-    from unittest.mock import AsyncMock
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     mgr = _make_mgr_with_metadata()
     mock_resp = MagicMock()
@@ -746,9 +744,7 @@ def test_format_response_awaits_async_gemini_call():
 
 def test_parse_user_query_falls_back_when_cache_none():
     """parse_user_query falls back to self.model when cache returns None."""
-    from unittest.mock import MagicMock, patch
-
-    from unittest.mock import AsyncMock
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     mgr = _make_mgr_with_metadata()
     mock_resp = MagicMock()

--- a/fastapi_app/tests/test_financial_utils.py
+++ b/fastapi_app/tests/test_financial_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import csv
 import logging
 import os
@@ -333,7 +334,7 @@ def test_parse_user_query_llm(monkeypatch, mock_bq_client):
 
     # Prepare a mock LLM model
     class MockLLM:
-        def generate_content(self, prompt):
+        async def generate_content_async(self, prompt):
             class Response:
                 # Simulate a realistic LLM output for a query about Elite Diagnostic Limited's revenue in 2024
                 text = '{"companies": ["Elite Diagnostic Limited"], "symbols": ["ELITE"], "years": ["2024"], "standard_items": ["revenue"], "interpretation": "Elite Diagnostic Limited revenue for 2024", "data_availability_note": "", "is_follow_up": false, "context_used": ""}'
@@ -367,7 +368,7 @@ def test_parse_user_query_llm(monkeypatch, mock_bq_client):
 
     # Test a realistic user query
     query = "Show me Elite Diagnostic Limited revenue for 2024"
-    filters = manager.parse_user_query(query)
+    filters = asyncio.run(manager.parse_user_query(query))
 
     # Assert the parsed filters match expected output
     assert isinstance(filters, FinancialDataFilters)
@@ -387,7 +388,7 @@ def test_parse_user_query_llm_multiple_companies_symbols(monkeypatch, mock_bq_cl
 
     # Prepare a mock LLM model
     class MockLLM:
-        def generate_content(self, prompt):
+        async def generate_content_async(self, prompt):
             class Response:
                 # Simulate LLM output for a query about two companies, two symbols, two years, and revenue
                 text = '{"companies": ["Elite Diagnostic Limited", "Dolla Financial Services Limited"], "symbols": ["ELITE", "DOLLA"], "years": ["2023", "2024"], "standard_items": ["revenue"], "interpretation": "Compare Elite Diagnostic Limited and Dolla Financial Services Limited revenue for 2023 and 2024", "data_availability_note": "", "is_follow_up": false, "context_used": ""}'
@@ -422,7 +423,7 @@ def test_parse_user_query_llm_multiple_companies_symbols(monkeypatch, mock_bq_cl
     }
 
     query = "Compare Elite Diagnostic Limited and Dolla Financial Services Limited revenue for 2023 and 2024"
-    filters = manager.parse_user_query(query)
+    filters = asyncio.run(manager.parse_user_query(query))
 
     assert isinstance(filters, FinancialDataFilters)
     assert set(filters.companies) == {
@@ -445,7 +446,7 @@ def test_parse_user_query_llm_symbol_only(monkeypatch, mock_bq_client):
 
     # Prepare a mock LLM model
     class MockLLM:
-        def generate_content(self, prompt):
+        async def generate_content_async(self, prompt):
             class Response:
                 # Simulate LLM output for a query about ELITE's revenue for 2024, only symbol provided
                 text = '{"companies": [], "symbols": ["ELITE"], "years": ["2024"], "standard_items": ["revenue"], "interpretation": "ELITE revenue for 2024", "data_availability_note": "", "is_follow_up": false, "context_used": ""}'
@@ -474,7 +475,7 @@ def test_parse_user_query_llm_symbol_only(monkeypatch, mock_bq_client):
     }
 
     query = "Show me ELITE revenue for 2024"
-    filters = manager.parse_user_query(query)
+    filters = asyncio.run(manager.parse_user_query(query))
 
     assert isinstance(filters, FinancialDataFilters)
     assert filters.symbols == ["ELITE"]
@@ -679,35 +680,83 @@ def test_parse_user_query_uses_cached_content_when_available():
     """parse_user_query passes cached_content= to generate_content when cache hits."""
     from unittest.mock import MagicMock, patch
 
+    from unittest.mock import AsyncMock
+
     mgr = _make_mgr_with_metadata()
     mock_resp = MagicMock()
     mock_resp.text = '{"companies":[],"symbols":["NCBFG"],"years":[],"standard_items":["revenue"],"interpretation":"test","data_availability_note":"","is_follow_up":false,"context_used":""}'
 
     mock_client = MagicMock()
-    mock_client.models.generate_content.return_value = mock_resp
+    mock_client.aio.models.generate_content = AsyncMock(return_value=mock_resp)
 
     with (
         patch("app.financial_utils._PARSE_QUERY_CACHE") as mock_cache,
         patch("app.financial_utils.get_genai_client", return_value=mock_client),
     ):
         mock_cache.get_cache_name.return_value = "cachedContents/parse123"
-        mgr.parse_user_query("What is NCBFG revenue?")
+        asyncio.run(mgr.parse_user_query("What is NCBFG revenue?"))
 
-    config = mock_client.models.generate_content.call_args.kwargs["config"]
+    config = mock_client.aio.models.generate_content.call_args.kwargs["config"]
     assert config.cached_content == "cachedContents/parse123"
+
+
+def test_format_response_awaits_async_gemini_call():
+    """format_response is async and must reach the model via generate_content_async.
+
+    Guards the ADR-0003 conversion: a regression back to the blocking
+    generate_content would leave this AsyncMock un-awaited and fail here.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.models import FinancialDataRecord
+
+    mgr = _make_mgr_with_metadata()
+    mgr.dspy_response_formatter = None
+
+    mock_resp = MagicMock()
+    mock_resp.text = "NCB Financial Group reported revenue of J$1.0 billion in 2023."
+    # Real usage metadata, so cost accounting doesn't compare a MagicMock to an int.
+    mock_resp.usage_metadata = None
+    mock_resp.candidates = []
+    mgr.model.generate_content_async = AsyncMock(return_value=mock_resp)
+
+    records = [
+        FinancialDataRecord(
+            company="NCB Financial Group",
+            symbol="NCBFG",
+            year="2023",
+            standard_item="revenue",
+            item=1_000_000_000.0,
+            unit_multiplier=1,
+            formatted_value="J$1.0B",
+        )
+    ]
+
+    result = asyncio.run(
+        mgr.format_response(
+            records=records,
+            query="What is NCBFG revenue?",
+            interpretation="NCBFG revenue for 2023",
+        )
+    )
+
+    mgr.model.generate_content_async.assert_awaited_once()
+    assert result == "NCB Financial Group reported revenue of J$1.0 billion in 2023."
 
 
 def test_parse_user_query_falls_back_when_cache_none():
     """parse_user_query falls back to self.model when cache returns None."""
     from unittest.mock import MagicMock, patch
 
+    from unittest.mock import AsyncMock
+
     mgr = _make_mgr_with_metadata()
     mock_resp = MagicMock()
     mock_resp.text = '{"companies":[],"symbols":["NCBFG"],"years":[],"standard_items":["revenue"],"interpretation":"test","data_availability_note":"","is_follow_up":false,"context_used":""}'
-    mgr.model.generate_content.return_value = mock_resp
+    mgr.model.generate_content_async = AsyncMock(return_value=mock_resp)
 
     with patch("app.financial_utils._PARSE_QUERY_CACHE") as mock_cache:
         mock_cache.get_cache_name.return_value = None
-        mgr.parse_user_query("What is NCBFG revenue?")
+        asyncio.run(mgr.parse_user_query("What is NCBFG revenue?"))
 
-    mgr.model.generate_content.assert_called_once()
+    mgr.model.generate_content_async.assert_awaited_once()

--- a/fastapi_app/tests/test_history_context.py
+++ b/fastapi_app/tests/test_history_context.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from app.financial_utils import FinancialDataManager
@@ -6,7 +8,7 @@ from app.financial_utils import FinancialDataManager
 @pytest.fixture
 def mock_llm():
     class MockLLM:
-        def generate_content(self, prompt):
+        async def generate_content_async(self, prompt):
             class Response:
                 text = '{"companies": ["Elite Diagnostic Limited"], "symbols": ["ELITE"], "years": ["2024"], "standard_items": ["revenue"], "interpretation": "Elite Diagnostic Limited revenue for 2024", "data_availability_note": "", "is_follow_up": true, "context_used": "conversation history"}'
 
@@ -27,7 +29,7 @@ def test_parse_user_query_with_history(monkeypatch):
     captured_prompt = []
 
     class MockLLM:
-        def generate_content(self, prompt):
+        async def generate_content_async(self, prompt):
             captured_prompt.append(prompt)
 
             class Response:
@@ -49,7 +51,7 @@ def test_parse_user_query_with_history(monkeypatch):
     ]
     query = "What about 2024?"
 
-    manager.parse_user_query(query, conversation_history=history)
+    asyncio.run(manager.parse_user_query(query, conversation_history=history))
 
     assert len(captured_prompt) > 0
     # Verify history is in the prompt

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -80,13 +80,23 @@ Both are visible in the code, and both shape what the numbers will look like:
 with `uvicorn app.main:app --host 0.0.0.0 --port 8000` — no `--workers`. One
 process, one event loop.
 
-**The Gemini calls are synchronous inside `async` endpoints.**
-`app/agent_v2.py` calls `self.client.models.generate_content(...)` directly in
-`_fast_path()` and `run()` — no `await`, no `asyncio.to_thread`. A blocking
-call on the event loop stops that loop from doing anything else, so with one
-worker the API serves roughly **one LLM request at a time** regardless of how
-many clients arrive. `_extract_grounded_symbols()` already uses
-`asyncio.to_thread`, so the pattern for fixing it exists in the file.
+**The Gemini calls are async; the BigQuery calls run on threads.** Gemini calls
+go through the SDKs' native async clients
+([ADR 0003](../docs/adr/0003-native-async-gemini-client.md)), so they yield the
+event loop. BigQuery has no first-party async client, so `query_data` and the
+interactions-log insert stay wrapped in `asyncio.to_thread`
+([ADR 0001](../docs/adr/0001-fix-event-loop-blocking-llm-calls.md)) and still
+consume a worker from a pool capped at `min(32, cpu_count + 4)` — which on a
+512-CPU-unit ECS task is about 5–6 workers, not 32.
 
-Run the sweep first and let it confirm or refute this on the real deployment
+Two failure signatures to recognise in the output:
+
+- **Throughput flat while p50 scales with concurrency** — serialisation, the
+  original ADR 0001 bug. Fixed, but worth spotting if it returns.
+- **Throughput peaking and then falling while p95 climbs to ~60s** —
+  saturation, with the 60s cluster being the ALB idle timeout converting
+  queued requests into HTTP 504s. This is what a dev sweep found at
+  concurrency 32 on 2026-08-16.
+
+Run the sweep and let it confirm or refute your theory on the real deployment
 before changing anything — the point of measuring is to not guess.


### PR DESCRIPTION
Closes #52.

## What changed

Replaces `asyncio.to_thread`-wrapped Gemini calls with each SDK's native async entry point, so an in-flight call yields the event loop instead of holding a thread-pool worker.

- **`google.genai`** → `client.aio.models.generate_content`: `agent_v2.py` (router, refusal, main generation), `document_selector.py`, and the cached-content branch of `financial_utils.parse_user_query`
- **`google.generativeai`** (deprecated) → `generate_content_async`: the legacy fallback in `parse_user_query`, and `format_response`
- **Unchanged — BigQuery keeps `asyncio.to_thread`.** `google-cloud-bigquery` has no first-party async client, so a thread remains the right tool for `query_data` and the interactions-log insert (ADR 0001).

`FinancialDataManager.parse_user_query` / `.format_response` become genuinely `async def`. `extract_companies_from_query` is split into sync and async variants sharing request-building and parsing helpers, so the synchronous document-selection subtree didn't need converting wholesale.

## Why it turned out to matter more than expected

ADR 0001 recorded the thread-pool cap as "not a limit at the concurrency levels tested," reading it as ~32 workers. The cap is `min(32, cpu_count + 4)` — the 32 is a ceiling, not the value. On the dev task's 512 CPU units that resolves to roughly **5–6 workers**, and it was the active constraint.

## Measured on dev (1 task, identical levels, before vs after)

| conc | rps before → after | p50 before → after | errors before → after |
|---|---|---|---|
| 1 | 0.08 → 0.04 † | 12.1s → 27.7s † | 0% → 0% |
| 4 | 0.14 → 0.31 | 11.6s → 11.9s | 0% → 0% |
| 16 | 0.44 → 0.92 | 29.6s → 12.2s | 0% → 0% |
| 32 | 0.24 → **1.83** | 42.7s → **13.2s** | **54.7%** → **0%** |

At concurrency 32: **7.6× throughput, 3.2× faster p50, and zero errors where 35 requests previously died as HTTP 504s.**

† Cold-start artefact, not a regression — two requests against a just-replaced container, with `queue*` of 18.6s vs 0.4s. Every later level settles at ~12–13s.

**The mechanism confirms the diagnosis, not just the outcome.** Effective in-flight requests (throughput × service time) went from ~5.3 to ~24 — exactly what removing a ~5-worker cap predicts.

## Where the new ceiling is

| conc | rps | p50 | errors | scaling efficiency |
|---|---|---|---|---|
| 32 | 1.69 | 13.6s | 0% | — |
| 64 | 2.94 | 14.2s | 0% | 87% |
| 128 | 3.69 | 17.6s | 0.4% (1×504) | 63% |

No collapse anywhere in range. Saturation begins near 128 as deceleration rather than a cliff: efficiency decays 87% → 63%, `queue*` rises 890ms → 2172ms, and one 504 reappears at 54.1s max. Effective in-flight at 128 is ~65 of 128 offered, so about half the load queues.

**Which limit this is has not been identified** — uvicorn worker, event loop, or Gemini quota are all candidates. That distinction matters because the first two scale with `--workers` or task count and quota does not. The broken `ai_request_duration_seconds` metric is what prevents settling it from this data.

## Verification

- Full test suite compared before/after by stashing the change: **identical set of 50 failures** (all pre-existing credential errors in the worktree), plus one new passing test. No regression introduced.
- `black` and `ruff` clean.
- Added `test_format_response_awaits_async_gemini_call` — `format_response` previously had no test at all, only a conftest mock. Uses `assert_awaited_once`, so a regression to a blocking call fails loudly.
- Deployed to dev (task definition revision 12, single `PRIMARY`/`COMPLETED`), `/health` all components healthy, and a live `/chat/stream` query returned a correct answer.

Total Gemini spend across all sweeps: ~$2.17.

## Docs

- **ADR 0003** (new) — this change, the before/after numbers, the mechanism check, and the located ceiling.
- **ADR 0002** (new) — staggered onboarding during testing, recorded as a decision while capacity was unproven. States plainly that the first wave of 100 invitations had already gone out unmitigated. Its own expiry condition is measurement, and this PR is that measurement, so it should be revisited once this reaches prod.
- **`loadtest/README.md`** — corrected. It still described the Gemini calls as synchronous with no `asyncio.to_thread`, which ADR 0001 fixed months ago.

## Follow-ups this surfaced (not in scope here)

- `financial_utils.py` still imports the fully-deprecated `google.generativeai`. `generate_content_async` narrows the exposure but doesn't remove it — migrating that module to `google.genai` warrants its own issue.
- `ai_request_duration_seconds` reads 0ms, so the load test can't split Gemini time from app time. Flagged in ADR 0001, still unaddressed, and now the specific thing blocking identification of the remaining ceiling.
- The 60s ALB idle timeout is what turns saturation into 504s. Worth being a deliberate choice rather than an inherited default.
- `fastapi_app/tests/archive/` imports `app.streaming_financial_chat`, a module path that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
