### PR TITLE
feat: return sources from all chat endpoints for fact-checking and provenance

### DIFF
--- a/docs/CHATBOT_INTEGRATION_SPEC.md
+++ b/docs/CHATBOT_INTEGRATION_SPEC.md
@@ -141,9 +141,27 @@ Contains the final response. **CRITICAL: This event MUST contain the response te
   "response": "Based on the analysis of financial documents...",
   "sources": [
     {
-      "title": "Annual Report 2023",
+      "type": "web",
+      "title": "Annual Report 2023 - Company XYZ",
+      "detail": "Grounded Google Search result",
+      "retrieved_at": "2026-08-17T12:00:00Z",
       "url": "https://...",
-      "relevance": 0.95
+      "domain": "example.com"
+    },
+    {
+      "type": "document",
+      "title": "ncb_annual_report_2023.pdf",
+      "detail": "Contains FY2023 net profit",
+      "document_id": "a1b2c3d4e5f60718",
+      "company": "NCB Financial Group",
+      "year": "2023"
+    },
+    {
+      "type": "dataset",
+      "title": "net_profit for NCB Financial Group",
+      "table": "project.dataset.financial_statements",
+      "filters": {"symbol": "NCB", "year": 2023},
+      "record_count": 4
     }
   ],
   "metadata": {
@@ -157,6 +175,44 @@ Contains the final response. **CRITICAL: This event MUST contain the response te
 - `response` (string, **REQUIRED**): The chatbot's answer
 - `sources` (array, optional): Source documents used
 - `metadata` (object, optional): Additional response metadata
+
+#### `Source` Object Shape
+
+Every entry in `sources` is a single polymorphic shape, `type`-discriminated. `type` and `title` are always present so a client that understands nothing else can still render a citation line; everything else is optional and varies by `type`.
+
+| Field | Type | Present on | Description |
+|-------|------|-------------|-------------|
+| `type` | string | all | `"web"`, `"document"`, or `"dataset"` |
+| `title` | string | all | Human-readable source name |
+| `detail` | string, optional | any | Why this source was used (LLM-generated) |
+| `retrieved_at` | string, optional | any | ISO 8601 time the underlying retrieval ran |
+| `url` | string, optional | web | Google grounding redirect URL |
+| `domain` | string, optional | web | Publisher domain |
+| `document_id` | string, optional | document | Opaque id, redeemable via `GET /documents/{document_id}` |
+| `company` | string, optional | document | Company the document belongs to |
+| `year` | string, optional | document | Reporting year of the document |
+| `table` | string, optional | dataset | Fully-qualified BigQuery table |
+| `filters` | object, optional | dataset | Filters applied when reading the table |
+| `record_count` | number, optional | dataset | Rows matched by the query |
+
+`web` sources come from Gemini's Google Search grounding chunks, `document` sources from PDFs the chatbot read out of S3, and `dataset` sources from BigQuery financial tables queried on your behalf. All three chat endpoints (`/chat`, `/chat/stream`, `/fast_chat_v2`) emit the same `sources` array shape.
+
+**Security note — treat every string in `sources` as untrusted:** `title`, `domain`, and `url` on a web source come from whatever page Gemini's grounding chose (a crafted query can steer what gets grounded on), and `detail` is model-generated. Escape `title`, `domain`, and `detail` before rendering them, and allowlist `url`'s scheme to `https:` before using it in an `href` — a `javascript:` URI arriving in a grounding chunk and rendered unescaped is clickable script execution.
+
+**Web `url` values expire (~30 days):** they are Google grounding redirect URLs, not permanent links. This is why `domain` exists alongside `url` — show `domain`/`title` in the UI so a citation still reads sensibly after its `url` has gone stale.
+
+#### Resolving Document Citations: `GET /documents/{document_id}`
+
+A `document` source's `document_id` is an opaque, non-reversible identifier — not an S3 path. Redeem it against the chatbot service (not the Django proxy) to get the actual file:
+
+```
+GET /documents/{document_id}
+```
+
+- **307 Temporary Redirect** to a presigned S3 URL, valid for 300 seconds, if `document_id` is known.
+- **404 Not Found** if `document_id` is unknown or unresolvable.
+
+The intended use is a plain browser navigation — `<a href="{base_url}/documents/{document_id}" target="_blank">` — which follows the redirect natively. A `fetch()` call instead follows the redirect cross-origin to S3 and needs the bucket's CORS policy to permit the calling origin, or must be issued with `redirect: 'manual'` and the `Location` header handled explicitly.
 
 ##### `complete` Event
 Status update indicating completion (does NOT contain response).

--- a/docs/superpowers/plans/2026-08-17-response-sources-provenance.md
+++ b/docs/superpowers/plans/2026-08-17-response-sources-provenance.md
@@ -1,0 +1,1523 @@
+# Response Sources & Provenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every chat endpoint returns a typed `sources` array so users can fact-check answers and the UI can render a citations panel.
+
+**Architecture:** One polymorphic `Source` model with a `type` discriminator (`web` / `document` / `dataset`) is returned by all three chat endpoints. Web sources come from Gemini grounding chunks, dataset sources from the BigQuery filters already computed, and document sources carry a non-forgeable `document_id` resolved on demand by a new `GET /documents/{id}` endpoint that issues short-lived presigned S3 URLs.
+
+**Tech Stack:** Python 3.10–3.12, FastAPI, Pydantic v2, boto3, google-genai, pytest, Redis (response cache), BigQuery.
+
+**Spec:** [`docs/superpowers/specs/2026-08-17-response-sources-provenance-design.md`](../specs/2026-08-17-response-sources-provenance-design.md)
+
+## Global Constraints
+
+- **All API changes are additive.** `type`, `title`, and `url` must keep serializing identically for web sources; `documents_loaded` stays on `ChatResponse`. A backward-compatibility test guards this.
+- **Line length 100.** Formatted with `black`, linted with `ruff` (config in `fastapi_app/pyproject.toml`).
+- **Python 3.10–3.12**, Pydantic v2 syntax (`model_dump`, not `dict`).
+- **`document_id` must never be a reversible encoding of an S3 path.** It is `sha256(s3_path)[:16]`, resolved only by lookup against `metadata.json`.
+- **Presigned URL TTL is 300 seconds.** Presigned URLs are never written to the Redis response cache.
+- **All commands run from `fastapi_app/`** (pytest is configured with `testpaths = ["tests"]`, `pythonpath = [".", "app"]`, `asyncio_mode = "auto"`, `--strict-markers`).
+- **Unit tests carry `@pytest.mark.unit`** and live in `fastapi_app/tests/unit/`.
+
+---
+
+### Task 0: Capture the regression baseline
+
+**Files:**
+- Create: `fastapi_app/baseline-tests.txt` (untracked scratch output; not committed)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `fastapi_app/baseline-tests.txt` — the suite's pass/fail state **before any change**, read by Task 7.
+
+This must run **first**, before a single line is edited. "No regressions" is only meaningful as a comparison against a known starting point, and this repo has pre-existing failures that would otherwise get blamed on this work. Capturing it later does not work: every task commits, so by Task 7 there are no uncommitted changes for `git stash` to set aside and the "baseline" would silently include the whole feature.
+
+- [ ] **Step 1: Confirm the working tree is clean and on the feature branch**
+
+```bash
+git status --short && git rev-parse --abbrev-ref HEAD
+```
+
+Expected: no output from `git status --short`. If there are uncommitted changes, stop and resolve them — the baseline would be meaningless.
+
+- [ ] **Step 2: Run the full suite and save the result**
+
+From `fastapi_app/`:
+
+```bash
+python -m pytest tests -q --no-cov > baseline-tests.txt 2>&1; tail -20 baseline-tests.txt
+```
+
+The path is deliberately repo-relative rather than `/tmp/...`: this is a Windows checkout, `/tmp` resolves differently between Git Bash and PowerShell, and native Python resolves it to `C:\tmp` rather than the shell's temp directory.
+
+- [ ] **Step 3: Record the counts**
+
+Note the final summary line (e.g. `12 failed, 340 passed, 5 skipped`) and the names of any failing tests. These are **pre-existing** and are not caused by this work. Task 7 compares against exactly this list.
+
+- [ ] **Step 4: Keep the file out of version control**
+
+`baseline-tests.txt` is scratch output. Do not `git add` it. Confirm it stays untracked:
+
+```bash
+git status --short fastapi_app/baseline-tests.txt
+```
+
+Expected: `?? fastapi_app/baseline-tests.txt` (untracked), never staged.
+
+---
+
+### Task 1: The `Source` model and response wiring
+
+**Files:**
+- Modify: `fastapi_app/app/models.py` (add `SourceType`, `Source`; wire into `ChatResponse:51`, `FinancialDataResponse:131`, `AgentChatResponse:253`)
+- Modify: `fastapi_app/app/main.py:1013` (wrap cached sources in `_jsonable`)
+- Test: `fastapi_app/tests/unit/test_source_model.py`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `SourceType` (str enum: `WEB="web"`, `DOCUMENT="document"`, `DATASET="dataset"`) and `Source` (Pydantic model; required `type: SourceType`, `title: str`; all other fields `Optional` defaulting to `None`). Every later task builds `Source` objects.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `fastapi_app/tests/unit/test_source_model.py`:
+
+```python
+"""Unit tests for the Source provenance model.
+
+Every chat endpoint returns a `sources` array so users can fact-check an
+answer. Only `type` and `title` are required, so a client that understands
+nothing else can still render a meaningful citation line.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import (
+    AgentChatResponse,
+    ChatResponse,
+    FinancialDataFilters,
+    FinancialDataResponse,
+    Source,
+    SourceType,
+)
+
+
+@pytest.mark.unit
+class TestSourceModel:
+    def test_web_source_keeps_legacy_shape(self):
+        """Existing clients read type/title/url. Those must serialize verbatim."""
+        source = Source(
+            type=SourceType.WEB,
+            title="Jamaica Stock Exchange",
+            url="https://vertexaisearch.example/redirect/abc",
+        )
+        dumped = source.model_dump()
+        assert dumped["type"] == "web"
+        assert dumped["title"] == "Jamaica Stock Exchange"
+        assert dumped["url"] == "https://vertexaisearch.example/redirect/abc"
+
+    def test_type_and_title_are_sufficient(self):
+        source = Source(type=SourceType.DATASET, title="JSE financial statements")
+        assert source.url is None
+        assert source.document_id is None
+        assert source.record_count is None
+
+    def test_title_is_required(self):
+        with pytest.raises(ValidationError):
+            Source(type=SourceType.WEB)
+
+    def test_agent_response_coerces_source_dicts(self):
+        """Redis returns plain dicts; the response model must coerce them."""
+        built = AgentChatResponse(
+            response="r",
+            data_found=True,
+            record_count=0,
+            sources=[{"type": "web", "title": "T", "url": "https://x"}],
+        )
+        assert built.sources[0].type == SourceType.WEB
+        assert built.sources[0].title == "T"
+
+    def test_financial_response_accepts_sources(self):
+        built = FinancialDataResponse(
+            response="r",
+            data_found=True,
+            record_count=2,
+            filters_used=FinancialDataFilters(),
+            sources=[{"type": "dataset", "title": "JSE financials", "record_count": 2}],
+        )
+        assert built.sources[0].type == SourceType.DATASET
+        assert built.sources[0].record_count == 2
+
+    def test_chat_response_accepts_sources_alongside_documents_loaded(self):
+        """documents_loaded is retained for backward compatibility."""
+        built = ChatResponse(
+            response="r",
+            documents_loaded=["ncb_annual_2023.pdf"],
+            sources=[{"type": "document", "title": "ncb_annual_2023.pdf", "document_id": "abc123"}],
+        )
+        assert built.documents_loaded == ["ncb_annual_2023.pdf"]
+        assert built.sources[0].document_id == "abc123"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_source_model.py -v --no-cov`
+Expected: FAIL with `ImportError: cannot import name 'Source' from 'app.models'`
+
+- [ ] **Step 3: Add the model to `app/models.py`**
+
+Insert after the `ChartSpec` class (currently ends at line 128), before `FinancialDataResponse`:
+
+```python
+class SourceType(str, Enum):
+    """Kind of evidence backing an answer."""
+
+    WEB = "web"  # Google Search grounding chunk
+    DOCUMENT = "document"  # PDF in S3
+    DATASET = "dataset"  # BigQuery financial table
+
+
+class Source(BaseModel):
+    """A single piece of provenance for an answer.
+
+    Only `type` and `title` are required — a client that understands nothing
+    else can still render a citation line. Per-type fields are optional so new
+    source kinds can be added without breaking existing consumers.
+    """
+
+    type: SourceType = Field(..., description="Kind of source backing the answer")
+    title: str = Field(..., description="Human-readable source name")
+    detail: Optional[str] = Field(default=None, description="Why this source was used")
+    retrieved_at: Optional[str] = Field(
+        default=None, description="ISO 8601 time the underlying retrieval ran"
+    )
+
+    # --- web ---
+    url: Optional[str] = Field(
+        default=None, description="Source URL. Gemini grounding URIs expire (~30 days)."
+    )
+    domain: Optional[str] = Field(
+        default=None, description="Publisher domain. Outlives an expired url."
+    )
+
+    # --- document ---
+    document_id: Optional[str] = Field(
+        default=None, description="Opaque id. Resolve via GET /documents/{document_id}"
+    )
+    company: Optional[str] = Field(default=None, description="Company the document belongs to")
+    year: Optional[str] = Field(default=None, description="Reporting year of the document")
+
+    # --- dataset ---
+    table: Optional[str] = Field(default=None, description="Fully-qualified BigQuery table")
+    filters: Optional[Dict[str, Any]] = Field(
+        default=None, description="Filters applied when reading the table"
+    )
+    record_count: Optional[int] = Field(default=None, description="Rows matched by the query")
+```
+
+- [ ] **Step 4: Wire `sources` into the three response models**
+
+In `ChatResponse` (line 51), add after `conversation_history`:
+
+```python
+    sources: Optional[List[Source]] = Field(
+        default=None, description="Provenance for the answer (document sources)"
+    )
+```
+
+In `FinancialDataResponse` (line 131), add after `chart`:
+
+```python
+    sources: Optional[List[Source]] = Field(
+        default=None, description="Provenance for the answer (dataset sources)"
+    )
+```
+
+In `AgentChatResponse` (line 253), replace the existing untyped `sources` field:
+
+```python
+    sources: Optional[List[Source]] = Field(
+        default=None, description="Provenance for the answer (web sources)"
+    )
+```
+
+- [ ] **Step 5: Fix the Redis serialization of sources**
+
+`main.py:1013` currently writes `"sources": response.sources` into the cache payload. That works only while sources are plain dicts — once they are `Source` objects, the Redis JSON write fails. Change that line to match its neighbours:
+
+```python
+                    "sources": _jsonable(response.sources),
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_source_model.py -v --no-cov`
+Expected: PASS (6 tests)
+
+- [ ] **Step 7: Verify no regression in existing tests**
+
+Run: `python -m pytest tests/unit tests/test_chat_stream_endpoint.py -v --no-cov`
+Expected: PASS, same count as before this task
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add fastapi_app/app/models.py fastapi_app/app/main.py fastapi_app/tests/unit/test_source_model.py
+git commit -m "feat(models): add typed Source model for answer provenance"
+```
+
+---
+
+### Task 2: Web sources from Gemini grounding
+
+**Files:**
+- Modify: `fastapi_app/app/agent_v2.py:268-327` (`_extract_grounding_metadata`)
+- Test: `fastapi_app/tests/unit/test_agent_v2_sources.py`
+
+**Interfaces:**
+- Consumes: `Source`, `SourceType` from Task 1.
+- Produces: `AgentV2._extract_grounding_metadata(response) -> Dict[str, Any]` with key `"sources"` now holding `List[Source]` (was `List[dict]`) and `"search_results"` unchanged.
+
+Two bugs are fixed alongside the model change: Gemini repeats the same grounding chunk across grounding supports, so the current list contains **duplicates**; and `domain` must be populated so a citation survives its URL expiring.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `fastapi_app/tests/unit/test_agent_v2_sources.py`:
+
+```python
+"""Unit tests for web source extraction from Gemini grounding metadata.
+
+Gemini returns one grounding chunk per grounding support, so the same URL
+appears several times in a single response — the extracted source list must
+be deduped. Grounding URIs are vertexaisearch redirects that expire after
+about 30 days, so `domain` is captured separately: when the link dies, the
+citation degrades to readable text instead of to nothing.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.agent_v2 import AgentV2
+from app.models import SourceType
+
+
+def _web_chunk(uri, title, domain=None):
+    """Build a grounding chunk.
+
+    `spec` is required: a bare MagicMock auto-creates any attribute, so
+    `getattr(web, "domain", None)` would return a Mock instead of None and the
+    fallback path would never be exercised.
+    """
+    spec = ["uri", "title"] + (["domain"] if domain is not None else [])
+    web = MagicMock(spec=spec)
+    web.uri = uri
+    web.title = title
+    if domain is not None:
+        web.domain = domain
+    chunk = MagicMock(spec=["web"])
+    chunk.web = web
+    return chunk
+
+
+def _grounded_response(chunks):
+    grounding = MagicMock(spec=["grounding_chunks", "web_search_queries", "search_entry_point"])
+    grounding.grounding_chunks = chunks
+    grounding.web_search_queries = ["ncb net profit 2023"]
+    entry_point = MagicMock(spec=["rendered_content"])
+    entry_point.rendered_content = "<div></div>"
+    grounding.search_entry_point = entry_point
+    candidate = MagicMock(spec=["grounding_metadata"])
+    candidate.grounding_metadata = grounding
+    response = MagicMock(spec=["candidates"])
+    response.candidates = [candidate]
+    return response
+
+
+@pytest.fixture
+def agent():
+    with patch("app.agent_v2.get_genai_client"):
+        yield AgentV2()
+
+
+@pytest.mark.unit
+class TestWebSourceExtraction:
+    def test_duplicate_urls_are_deduped(self, agent):
+        response = _grounded_response(
+            [
+                _web_chunk("https://jse.com/a", "jamstockex.com"),
+                _web_chunk("https://jse.com/a", "jamstockex.com"),
+                _web_chunk("https://jse.com/b", "jamstockex.com"),
+            ]
+        )
+        sources = agent._extract_grounding_metadata(response)["sources"]
+        assert len(sources) == 2
+        assert [s.url for s in sources] == ["https://jse.com/a", "https://jse.com/b"]
+
+    def test_sources_are_typed_web(self, agent):
+        response = _grounded_response([_web_chunk("https://jse.com/a", "jamstockex.com")])
+        source = agent._extract_grounding_metadata(response)["sources"][0]
+        assert source.type == SourceType.WEB
+        assert source.title == "jamstockex.com"
+
+    def test_domain_field_is_preferred_when_present(self, agent):
+        response = _grounded_response(
+            [_web_chunk("https://x/a", "JSE Annual Review", domain="jamstockex.com")]
+        )
+        source = agent._extract_grounding_metadata(response)["sources"][0]
+        assert source.domain == "jamstockex.com"
+        assert source.title == "JSE Annual Review"
+
+    def test_domain_falls_back_to_title(self, agent):
+        response = _grounded_response([_web_chunk("https://x/a", "jamstockex.com")])
+        source = agent._extract_grounding_metadata(response)["sources"][0]
+        assert source.domain == "jamstockex.com"
+
+    def test_retrieved_at_is_populated(self, agent):
+        response = _grounded_response([_web_chunk("https://x/a", "jamstockex.com")])
+        source = agent._extract_grounding_metadata(response)["sources"][0]
+        assert source.retrieved_at is not None
+        assert "T" in source.retrieved_at  # ISO 8601
+
+    def test_chunks_without_uri_are_skipped(self, agent):
+        response = _grounded_response([_web_chunk("", "jamstockex.com")])
+        assert agent._extract_grounding_metadata(response)["sources"] == []
+
+    def test_no_candidates_yields_no_sources(self, agent):
+        response = MagicMock(spec=["candidates"])
+        response.candidates = []
+        assert agent._extract_grounding_metadata(response)["sources"] == []
+
+    def test_search_results_still_populated(self, agent):
+        """web_search_results is a separate field and must not change shape."""
+        response = _grounded_response([_web_chunk("https://x/a", "jamstockex.com")])
+        results = agent._extract_grounding_metadata(response)["search_results"]
+        assert results["queries"] == ["ncb net profit 2023"]
+        assert results["grounding_chunks"] == [{"title": "jamstockex.com", "uri": "https://x/a"}]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_agent_v2_sources.py -v --no-cov`
+Expected: FAIL — `test_duplicate_urls_are_deduped` gets 3 sources instead of 2, and `AttributeError: 'dict' object has no attribute 'url'` on the typed assertions.
+
+- [ ] **Step 3: Rewrite the chunk loop in `_extract_grounding_metadata`**
+
+In `app/agent_v2.py`, replace lines 296–320 (from `# Extract grounding chunks (web sources)` through the `if grounding_chunks:` block) with:
+
+```python
+        # Extract grounding chunks (web sources).
+        # Gemini emits one chunk per grounding support, so the same URL can
+        # appear many times — dedupe while preserving first-seen order.
+        chunks = getattr(grounding, "grounding_chunks", []) or []
+        grounding_chunks = []
+        retrieved_at = datetime.now(timezone.utc).isoformat()
+        seen_urls = set()
+
+        for chunk in chunks:
+            if not (hasattr(chunk, "web") and chunk.web):
+                continue
+            web = chunk.web
+            uri = getattr(web, "uri", "") or ""
+            title = getattr(web, "title", "") or ""
+            grounding_chunks.append({"title": title, "uri": uri})
+
+            if not uri or uri in seen_urls:
+                continue
+            seen_urls.add(uri)
+
+            # Newer SDKs expose web.domain; older ones put the site domain in
+            # web.title. Either way the citation stays readable once the
+            # redirect URI expires.
+            domain = getattr(web, "domain", None) or title or None
+            sources.append(
+                Source(
+                    type=SourceType.WEB,
+                    title=title or domain or uri,
+                    url=uri,
+                    domain=domain,
+                    retrieved_at=retrieved_at,
+                )
+            )
+
+        if grounding_chunks:
+            search_results["grounding_chunks"] = grounding_chunks
+```
+
+- [ ] **Step 4: Add the imports**
+
+At the top of `app/agent_v2.py`, add to the existing `from app.models import ...` line (line 23) and add the datetime import:
+
+```python
+from datetime import datetime, timezone
+```
+
+```python
+from app.models import CostSummary, PhaseCost, Source, SourceType
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_agent_v2_sources.py -v --no-cov`
+Expected: PASS (8 tests)
+
+- [ ] **Step 6: Verify the agent's existing tests still pass**
+
+Run: `python -m pytest tests/test_agent_v2_grounding.py tests/test_agent_v2_router.py tests/test_chat_stream_endpoint.py -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add fastapi_app/app/agent_v2.py fastapi_app/tests/unit/test_agent_v2_sources.py
+git commit -m "feat(agent): emit typed, deduped web sources from grounding metadata"
+```
+
+---
+
+### Task 3: Document registry and the resolver endpoint
+
+**Files:**
+- Create: `fastapi_app/app/document_registry.py`
+- Modify: `fastapi_app/app/main.py` (build index in `lifespan` after metadata load ~line 68; add `get_document_index` dependency near line 216; add `GET /documents/{document_id}` endpoint)
+- Test: `fastapi_app/tests/unit/test_document_registry.py`, `fastapi_app/tests/test_documents_endpoint.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `make_document_id(s3_path: str) -> str` — 16-char hex.
+  - `build_document_index(metadata: Optional[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]` — maps `document_id` to `{"s3_path", "filename", "company", "year"}`.
+  - `parse_s3_path(s3_path: str) -> Tuple[str, str]` — `(bucket, key)`; raises `ValueError` on a malformed path.
+  - `presign_document(s3_client, s3_path: str, expires_in: int = 300) -> str`.
+  - `app.state.document_index` and the `get_document_index()` FastAPI dependency.
+
+S3 metadata is shaped `{company_name: [document, ...]}` where each document carries `document_link` (an `s3://bucket/key` string) and `filename`.
+
+- [ ] **Step 1: Write the failing registry test**
+
+Create `fastapi_app/tests/unit/test_document_registry.py`:
+
+```python
+"""Unit tests for the document registry.
+
+`document_id` is deliberately a one-way hash rather than an encoded S3 path.
+If it were reversible (e.g. base64), a client could edit the id and read
+arbitrary objects out of the bucket through our own resolver endpoint.
+Because resolution is a dict lookup built from metadata.json, no crafted
+input can reach an object we did not index.
+"""
+
+import pytest
+
+from app.document_registry import (
+    build_document_index,
+    make_document_id,
+    parse_s3_path,
+)
+
+METADATA = {
+    "NCB Financial Group": [
+        {
+            "filename": "ncb_annual_report_2023.pdf",
+            "document_link": "s3://jse-renamed-docs-copy-2/organized/ncb/annual_2023.pdf",
+            "year": "2023",
+        },
+        {
+            "filename": "ncb_q4_2023.pdf",
+            "document_link": "s3://jse-renamed-docs-copy-2/organized/ncb/q4_2023.pdf",
+            "period": "2023",
+        },
+    ],
+    "GraceKennedy": [
+        {
+            "filename": "gk_annual_report_2024.pdf",
+            "document_link": "s3://jse-renamed-docs-copy-2/organized/gk/annual_2024.pdf",
+            "year": "2024",
+        }
+    ],
+}
+
+
+@pytest.mark.unit
+class TestMakeDocumentId:
+    def test_is_stable(self):
+        path = "s3://bucket/key.pdf"
+        assert make_document_id(path) == make_document_id(path)
+
+    def test_is_sixteen_hex_chars(self):
+        doc_id = make_document_id("s3://bucket/key.pdf")
+        assert len(doc_id) == 16
+        assert all(c in "0123456789abcdef" for c in doc_id)
+
+    def test_differs_per_path(self):
+        assert make_document_id("s3://bucket/a.pdf") != make_document_id("s3://bucket/b.pdf")
+
+    def test_leaks_no_path_material(self):
+        """The id must not reveal bucket or key — it is a lookup key, not a codec."""
+        doc_id = make_document_id("s3://secret-bucket/organized/private.pdf")
+        assert "secret-bucket" not in doc_id
+        assert "private" not in doc_id
+        assert "organized" not in doc_id
+
+
+@pytest.mark.unit
+class TestBuildDocumentIndex:
+    def test_indexes_every_document(self):
+        index = build_document_index(METADATA)
+        assert len(index) == 3
+
+    def test_entry_carries_resolution_fields(self):
+        index = build_document_index(METADATA)
+        doc_id = make_document_id("s3://jse-renamed-docs-copy-2/organized/gk/annual_2024.pdf")
+        entry = index[doc_id]
+        assert entry["s3_path"] == "s3://jse-renamed-docs-copy-2/organized/gk/annual_2024.pdf"
+        assert entry["filename"] == "gk_annual_report_2024.pdf"
+        assert entry["company"] == "GraceKennedy"
+        assert entry["year"] == "2024"
+
+    def test_period_is_used_when_year_is_absent(self):
+        index = build_document_index(METADATA)
+        doc_id = make_document_id("s3://jse-renamed-docs-copy-2/organized/ncb/q4_2023.pdf")
+        assert index[doc_id]["year"] == "2023"
+
+    def test_documents_without_a_link_are_skipped(self):
+        index = build_document_index({"ACME": [{"filename": "no_link.pdf"}]})
+        assert index == {}
+
+    def test_none_metadata_yields_empty_index(self):
+        assert build_document_index(None) == {}
+
+    def test_malformed_metadata_is_tolerated(self):
+        """Metadata comes from S3 — a bad shape must not crash startup."""
+        assert build_document_index({"ACME": "not-a-list"}) == {}
+        assert build_document_index({"ACME": ["not-a-dict"]}) == {}
+
+
+@pytest.mark.unit
+class TestParseS3Path:
+    def test_splits_bucket_and_key(self):
+        assert parse_s3_path("s3://my-bucket/a/b/c.pdf") == ("my-bucket", "a/b/c.pdf")
+
+    def test_rejects_non_s3_scheme(self):
+        with pytest.raises(ValueError):
+            parse_s3_path("https://my-bucket/a.pdf")
+
+    def test_rejects_bucket_without_key(self):
+        with pytest.raises(ValueError):
+            parse_s3_path("s3://my-bucket")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_document_registry.py -v --no-cov`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.document_registry'`
+
+- [ ] **Step 3: Create `app/document_registry.py`**
+
+```python
+"""Stable, non-forgeable identifiers for the S3 documents we cite.
+
+A cited document is exposed to clients as an opaque `document_id`, never as
+an S3 path. The id is a truncated SHA-256 of the path and is resolved by a
+dict lookup built from metadata.json, so a client cannot craft an id that
+reaches an object we did not index. Presigned URLs are minted per request
+and never cached, so a cached response can never hand out a dead link.
+"""
+
+import hashlib
+from typing import Any, Dict, Optional, Tuple
+
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+DOCUMENT_ID_LENGTH = 16
+PRESIGNED_URL_TTL_SECONDS = 300
+
+
+def make_document_id(s3_path: str) -> str:
+    """Derive a stable, one-way id for an S3 path."""
+    return hashlib.sha256(s3_path.encode("utf-8")).hexdigest()[:DOCUMENT_ID_LENGTH]
+
+
+def parse_s3_path(s3_path: str) -> Tuple[str, str]:
+    """Split an ``s3://bucket/key`` path into ``(bucket, key)``."""
+    if not s3_path or not s3_path.startswith("s3://"):
+        raise ValueError(f"Not an s3:// path: {s3_path!r}")
+    remainder = s3_path[len("s3://") :]
+    bucket, _, key = remainder.partition("/")
+    if not bucket or not key:
+        raise ValueError(f"S3 path is missing a bucket or key: {s3_path!r}")
+    return bucket, key
+
+
+def build_document_index(metadata: Optional[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Map document_id -> resolution info for every document in S3 metadata.
+
+    Metadata is shaped ``{company_name: [document, ...]}``. It is loaded from
+    S3 at startup, so a malformed shape is tolerated rather than fatal.
+    """
+    index: Dict[str, Dict[str, Any]] = {}
+    if not metadata or not isinstance(metadata, dict):
+        return index
+
+    for company, documents in metadata.items():
+        if not isinstance(documents, list):
+            continue
+        for doc in documents:
+            if not isinstance(doc, dict):
+                continue
+            s3_path = doc.get("document_link")
+            if not s3_path:
+                continue
+            index[make_document_id(s3_path)] = {
+                "s3_path": s3_path,
+                "filename": doc.get("filename") or s3_path.rsplit("/", 1)[-1],
+                "company": company,
+                "year": doc.get("year") or doc.get("period"),
+            }
+
+    logger.info(f"Document index built: {len(index)} documents")
+    return index
+
+
+def presign_document(
+    s3_client: Any, s3_path: str, expires_in: int = PRESIGNED_URL_TTL_SECONDS
+) -> str:
+    """Mint a short-lived presigned GET URL for a document."""
+    bucket, key = parse_s3_path(s3_path)
+    return s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=expires_in,
+    )
+```
+
+- [ ] **Step 4: Run registry tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_document_registry.py -v --no-cov`
+Expected: PASS (13 tests)
+
+- [ ] **Step 5: Write the failing endpoint test**
+
+Create `fastapi_app/tests/test_documents_endpoint.py`:
+
+```python
+"""Tests for GET /documents/{document_id}.
+
+The resolver is the only path from a citation to the underlying PDF. It must
+resolve exactly the documents present in metadata.json and nothing else — an
+unknown or tampered id gets a 404, never a presigned URL.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.document_registry import build_document_index, make_document_id
+from app.main import app
+
+S3_PATH = "s3://jse-renamed-docs-copy-2/organized/ncb/annual_2023.pdf"
+METADATA = {
+    "NCB Financial Group": [
+        {
+            "filename": "ncb_annual_report_2023.pdf",
+            "document_link": S3_PATH,
+            "year": "2023",
+        }
+    ]
+}
+
+
+@pytest.fixture
+def client():
+    app.state.metadata = METADATA
+    app.state.document_index = build_document_index(METADATA)
+    mock_s3 = MagicMock()
+    mock_s3.generate_presigned_url.return_value = "https://s3.example/presigned?sig=abc"
+    app.state.s3_client = mock_s3
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.mark.integration
+class TestDocumentResolver:
+    def test_known_id_redirects_to_presigned_url(self, client):
+        doc_id = make_document_id(S3_PATH)
+        response = client.get(f"/documents/{doc_id}", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "https://s3.example/presigned?sig=abc"
+
+    def test_presigned_url_is_short_lived(self, client):
+        doc_id = make_document_id(S3_PATH)
+        client.get(f"/documents/{doc_id}", follow_redirects=False)
+        _, kwargs = app.state.s3_client.generate_presigned_url.call_args
+        assert kwargs["ExpiresIn"] == 300
+        assert kwargs["Params"]["Bucket"] == "jse-renamed-docs-copy-2"
+        assert kwargs["Params"]["Key"] == "organized/ncb/annual_2023.pdf"
+
+    def test_unknown_id_returns_404(self, client):
+        response = client.get("/documents/0000000000000000", follow_redirects=False)
+        assert response.status_code == 404
+        app.state.s3_client.generate_presigned_url.assert_not_called()
+
+    def test_tampered_id_returns_404(self, client):
+        """Flipping one character must not resolve to anything."""
+        doc_id = make_document_id(S3_PATH)
+        tampered = ("0" if doc_id[0] != "0" else "1") + doc_id[1:]
+        response = client.get(f"/documents/{tampered}", follow_redirects=False)
+        assert response.status_code == 404
+        app.state.s3_client.generate_presigned_url.assert_not_called()
+
+    def test_path_traversal_attempt_does_not_resolve(self, client):
+        response = client.get("/documents/..%2F..%2Fetc%2Fpasswd", follow_redirects=False)
+        assert response.status_code == 404
+        app.state.s3_client.generate_presigned_url.assert_not_called()
+```
+
+- [ ] **Step 6: Run endpoint test to verify it fails**
+
+Run: `python -m pytest tests/test_documents_endpoint.py -v --no-cov`
+Expected: FAIL with 404 on the known-id case (route does not exist yet)
+
+- [ ] **Step 7: Wire the index into app startup**
+
+In `app/main.py`, add the import beside the other app imports:
+
+```python
+from app.document_registry import build_document_index, presign_document
+```
+
+and `RedirectResponse` to the existing `fastapi.responses` import:
+
+```python
+from fastapi.responses import StreamingResponse, JSONResponse, Response, RedirectResponse
+```
+
+In `lifespan`, immediately after the metadata `try/except` block that sets `app.state.metadata` (around line 79), add:
+
+```python
+        # Index documents for citation resolution (GET /documents/{id}).
+        app.state.document_index = build_document_index(app.state.metadata)
+```
+
+- [ ] **Step 8: Add the dependency and the endpoint**
+
+Beside `get_metadata()` (line 216) add:
+
+```python
+def get_document_index():
+    return getattr(app.state, "document_index", {}) or {}
+```
+
+Add the endpoint after the `/financial/metadata` endpoint:
+
+```python
+@app.get("/documents/{document_id}")
+async def resolve_document(
+    document_id: str,
+    s3_client: Any = Depends(get_s3_client),
+    document_index: Dict = Depends(get_document_index),
+):
+    """Resolve a cited document to a short-lived presigned S3 URL.
+
+    `document_id` is a one-way hash, so this is a lookup against the documents
+    present in metadata.json — an id we did not mint resolves to nothing.
+    """
+    entry = document_index.get(document_id)
+    if not entry:
+        logger.info(f"document_resolve_miss id={document_id[:32]}")
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    try:
+        url = presign_document(s3_client, entry["s3_path"])
+    except ValueError as e:
+        logger.error(f"document_resolve_bad_path id={document_id}: {e}")
+        raise HTTPException(status_code=404, detail="Document not found")
+    except Exception as e:
+        logger.error(f"document_resolve_failed id={document_id}: {e}")
+        raise HTTPException(status_code=500, detail="Could not resolve document")
+
+    return RedirectResponse(url=url, status_code=307)
+```
+
+- [ ] **Step 9: Run endpoint tests to verify they pass**
+
+Run: `python -m pytest tests/test_documents_endpoint.py -v --no-cov`
+Expected: PASS (5 tests)
+
+- [ ] **Step 10: Verify no regression**
+
+Run: `python -m pytest tests/unit tests/test_api.py -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add fastapi_app/app/document_registry.py fastapi_app/app/main.py fastapi_app/tests/unit/test_document_registry.py fastapi_app/tests/test_documents_endpoint.py
+git commit -m "feat(documents): add document registry and GET /documents/{id} resolver"
+```
+
+---
+
+### Task 4: Document sources on `/chat`
+
+**Files:**
+- Modify: `fastapi_app/app/document_selector.py` (add `DocumentLoadResult`; change returns of `auto_load_relevant_documents:479` and `auto_load_relevant_documents_async:564`)
+- Modify: `fastapi_app/app/main.py:477-520` (`/chat` endpoint)
+- Modify: `fastapi_app/app/_archive/streaming_chat.py:165-173`
+- Modify: `fastapi_app/tests/unit/test_document_selector.py:49,58`; `fastapi_app/tests/test_async_s3_downloads.py:407,455`; `fastapi_app/test_async_integration.py:149`
+- Test: `fastapi_app/tests/unit/test_document_sources.py`
+
+**Interfaces:**
+- Consumes: `Source`, `SourceType` (Task 1); `make_document_id` (Task 3).
+- Produces: `DocumentLoadResult` dataclass with fields `texts: Dict[str, str]`, `message: str`, `loaded_docs: List[str]`, `sources: List[Source]`. Both loader functions return it instead of a 3-tuple.
+
+The loaders already have `document_link` and `reason` in scope inside the load loop and discard them. Seven call sites unpack or assert the tuple; all are updated in this task.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `fastapi_app/tests/unit/test_document_sources.py`:
+
+```python
+"""Unit tests for document provenance returned by the /chat loader.
+
+The loader has always had document_link and the selection reason in scope
+and thrown them away, returning bare filenames. Users fact-checking an
+answer need to reach the actual PDF, so the loader now returns Source
+objects carrying an opaque document_id the resolver endpoint can redeem.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.document_registry import make_document_id
+from app.document_selector import DocumentLoadResult, auto_load_relevant_documents
+from app.models import SourceType
+
+S3_PATH = "s3://jse-renamed-docs-copy-2/organized/ncb/annual_2023.pdf"
+
+RECOMMENDATION = {
+    "companies_mentioned": ["NCB Financial Group"],
+    "documents_to_load": [
+        {
+            "company": "NCB Financial Group",
+            "document_link": S3_PATH,
+            "filename": "ncb_annual_report_2023.pdf",
+            "reason": "Contains FY2023 net profit",
+        }
+    ],
+}
+
+
+@pytest.fixture
+def loaded():
+    with patch("app.document_selector.semantic_document_selection") as mock_select, patch(
+        "app.document_selector.download_and_extract_from_s3"
+    ) as mock_download:
+        mock_select.return_value = RECOMMENDATION
+        mock_download.return_value = "extracted pdf text"
+        yield auto_load_relevant_documents(
+            s3_client=Mock(),
+            query="NCB net profit 2023",
+            metadata={"NCB Financial Group": []},
+            current_document_texts={},
+        )
+
+
+@pytest.mark.unit
+class TestDocumentSources:
+    def test_returns_a_document_load_result(self, loaded):
+        assert isinstance(loaded, DocumentLoadResult)
+
+    def test_loaded_docs_still_lists_filenames(self, loaded):
+        """Backward compatibility: ChatResponse.documents_loaded is unchanged."""
+        assert loaded.loaded_docs == ["ncb_annual_report_2023.pdf"]
+
+    def test_texts_are_keyed_by_filename(self, loaded):
+        assert loaded.texts["ncb_annual_report_2023.pdf"] == "extracted pdf text"
+
+    def test_source_is_typed_document(self, loaded):
+        assert loaded.sources[0].type == SourceType.DOCUMENT
+
+    def test_source_carries_resolvable_document_id(self, loaded):
+        assert loaded.sources[0].document_id == make_document_id(S3_PATH)
+
+    def test_source_never_exposes_the_s3_path(self, loaded):
+        """The bucket layout must not reach the browser."""
+        dumped = loaded.sources[0].model_dump()
+        assert S3_PATH not in str(dumped)
+        assert "jse-renamed-docs-copy-2" not in str(dumped)
+
+    def test_source_carries_selection_reason_and_company(self, loaded):
+        source = loaded.sources[0]
+        assert source.title == "ncb_annual_report_2023.pdf"
+        assert source.detail == "Contains FY2023 net profit"
+        assert source.company == "NCB Financial Group"
+        assert source.retrieved_at is not None
+
+    def test_failed_download_produces_no_source(self):
+        """A document we could not read must not be cited as evidence."""
+        with patch("app.document_selector.semantic_document_selection") as mock_select, patch(
+            "app.document_selector.download_and_extract_from_s3"
+        ) as mock_download:
+            mock_select.return_value = RECOMMENDATION
+            mock_download.return_value = None
+            result = auto_load_relevant_documents(
+                s3_client=Mock(),
+                query="NCB net profit 2023",
+                metadata={"NCB Financial Group": []},
+                current_document_texts={},
+            )
+        assert result.loaded_docs == []
+        assert result.sources == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_document_sources.py -v --no-cov`
+Expected: FAIL with `ImportError: cannot import name 'DocumentLoadResult'`
+
+- [ ] **Step 3: Add the dataclass and imports to `document_selector.py`**
+
+At the top of `app/document_selector.py`, add:
+
+```python
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from app.document_registry import make_document_id
+from app.models import Source, SourceType
+```
+
+Add the dataclass after the module's imports:
+
+```python
+@dataclass
+class DocumentLoadResult:
+    """What a document-loading pass produced.
+
+    Replaces the old 3-tuple: callers needed a fourth value (`sources`), and
+    growing the tuple would have broken every unpacking site anyway.
+    """
+
+    texts: Dict[str, str]
+    message: str
+    loaded_docs: List[str] = field(default_factory=list)
+    sources: List[Source] = field(default_factory=list)
+```
+
+- [ ] **Step 4: Build sources in `auto_load_relevant_documents`**
+
+Replace the body of `auto_load_relevant_documents` (lines 498–556) with:
+
+```python
+    document_texts = current_document_texts.copy() if current_document_texts else {}
+    loaded_docs = []
+    sources: List[Source] = []
+
+    # Use two-stage LLM approach to determine which documents to load
+    recommendation = semantic_document_selection(
+        query, metadata, conversation_history, associations
+    )
+
+    if not recommendation or "documents_to_load" not in recommendation:
+        return DocumentLoadResult(
+            texts=document_texts,
+            message="No relevant documents were identified for your query.",
+        )
+
+    docs_to_load = recommendation["documents_to_load"]
+
+    # Load the recommended documents (limited to 3)
+    for doc_info in docs_to_load[:3]:
+        doc_link = doc_info["document_link"]
+        doc_name = doc_info["filename"]
+
+        # Only load if not already loaded
+        if doc_name in document_texts:
+            continue
+
+        load_start = time.time()
+        try:
+            text = download_and_extract_from_s3(s3_client, doc_link)
+            load_duration = time.time() - load_start
+            if text:
+                document_texts[doc_name] = text
+                loaded_docs.append(doc_name)
+                # Only cite a document we actually read.
+                sources.append(
+                    Source(
+                        type=SourceType.DOCUMENT,
+                        title=doc_name,
+                        detail=doc_info.get("reason"),
+                        document_id=make_document_id(doc_link),
+                        company=doc_info.get("company"),
+                        year=doc_info.get("year") or doc_info.get("period"),
+                        retrieved_at=datetime.now(timezone.utc).isoformat(),
+                    )
+                )
+                record_document_load(source="s3", duration=load_duration, success=True)
+            else:
+                record_document_load(source="error", duration=load_duration, success=False)
+        except Exception as e:
+            load_duration = time.time() - load_start
+            record_document_load(source="error", duration=load_duration, success=False)
+            logger.error(
+                "document_load_failed",
+                extra={
+                    "document": doc_name,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+            )
+
+    if not loaded_docs:
+        return DocumentLoadResult(
+            texts=document_texts,
+            message=(
+                "No documents were loaded. Please check S3 access permissions "
+                "or document availability."
+            ),
+        )
+
+    message = f"Semantically selected {len(loaded_docs)} documents based on your query:\n"
+    for doc_name in loaded_docs:
+        matching_doc = next((d for d in docs_to_load if d["filename"] == doc_name), None)
+        if matching_doc:
+            message += f"• {doc_name} - {matching_doc.get('reason', '')}\n"
+
+    return DocumentLoadResult(
+        texts=document_texts,
+        message=message,
+        loaded_docs=loaded_docs,
+        sources=sources,
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_document_sources.py -v --no-cov`
+Expected: PASS (8 tests)
+
+- [ ] **Step 6: Apply the same change to the async loader**
+
+In `auto_load_relevant_documents_async` (line 564), build a `sources` list the same way — append a `Source` for each document whose download succeeded (the loop that appends to `loaded_docs` around line 670) — and return `DocumentLoadResult(texts=..., message=..., loaded_docs=..., sources=...)` at each of its return points (lines ~697–712 and the early-return path).
+
+The async loader is used only by archived code and tests today, but letting the pair diverge is how it rots.
+
+- [ ] **Step 7: Update the `/chat` endpoint**
+
+In `app/main.py`, replace lines 477–484:
+
+```python
+            load_result = auto_load_relevant_documents(
+                s3_client,
+                request.query,
+                metadata,
+                {},  # Start with empty document_texts since this is stateless
+                request.conversation_history,
+                associations,
+            )
+            document_texts = load_result.texts
+            document_selection_message = load_result.message
+            loaded_docs = load_result.loaded_docs
+            doc_sources = load_result.sources
+```
+
+Initialise `doc_sources = []` beside `loaded_docs = []` in the variable setup (line 468), and add the field to the returned `ChatResponse` (line 515):
+
+```python
+        return ChatResponse(
+            response=response_text,
+            documents_loaded=loaded_docs if loaded_docs else None,
+            document_selection_message=document_selection_message,
+            conversation_history=updated_conversation_history,
+            sources=doc_sources if doc_sources else None,
+        )
+```
+
+- [ ] **Step 8: Update the remaining call sites**
+
+- `fastapi_app/app/_archive/streaming_chat.py:165-173` — replace tuple unpacking with `load_result = await auto_load_relevant_documents_async(...)` then read `.texts`, `.message`, `.loaded_docs`.
+- `fastapi_app/tests/test_async_s3_downloads.py:407,455` — replace `document_texts, message, loaded_docs = await ...` with `result = await ...` and read the attributes.
+- `fastapi_app/test_async_integration.py:149` — same change.
+- `fastapi_app/tests/unit/test_document_selector.py:53,64` — these assert `isinstance(result, tuple)` and `len(result) == 3`. Replace both with:
+
+```python
+            assert isinstance(result, DocumentLoadResult)
+            assert isinstance(result.texts, dict)
+            assert isinstance(result.loaded_docs, list)
+            assert isinstance(result.sources, list)
+```
+
+and add `DocumentLoadResult` to that file's imports from `app.document_selector`.
+
+- [ ] **Step 9: Run the full affected suite**
+
+Run: `python -m pytest tests/unit tests/test_async_s3_downloads.py tests/test_api.py -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add fastapi_app/app/document_selector.py fastapi_app/app/main.py fastapi_app/app/_archive/streaming_chat.py fastapi_app/tests fastapi_app/test_async_integration.py
+git commit -m "feat(chat): return document sources with resolvable ids from /chat"
+```
+
+---
+
+### Task 5: Dataset sources on `/fast_chat_v2`
+
+**Files:**
+- Modify: `fastapi_app/app/financial_utils.py` (add `FinancialDataManager.describe_source`)
+- Modify: `fastapi_app/app/main.py:707-744` (`/fast_chat_v2` cache write and response) and `main.py:631-641` (cache-hit response)
+- Test: `fastapi_app/tests/unit/test_dataset_source.py`
+
+**Interfaces:**
+- Consumes: `Source`, `SourceType` (Task 1).
+- Produces: `FinancialDataManager.describe_source(filters: FinancialDataFilters, record_count: int) -> Source`.
+
+Per the spec, `filters` carries only the four query-shaping fields — `companies`, `symbols`, `years`, `standard_items`. The conversational fields describe how the query was understood, not which data was read, and `filters_used` already carries the full object.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `fastapi_app/tests/unit/test_dataset_source.py`:
+
+```python
+"""Unit tests for dataset provenance on /fast_chat_v2.
+
+A financial figure's honest provenance is the table it came from plus the
+filters applied — not a fabricated per-number URL. See the known limitation
+in the design doc: the table has no column pointing back to the statement
+PDF, so a dataset source deliberately stops at the query.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.financial_utils import FinancialDataManager
+from app.models import FinancialDataFilters, SourceType
+
+
+@pytest.fixture
+def manager():
+    with patch.object(FinancialDataManager, "__init__", lambda self: None):
+        mgr = FinancialDataManager()
+    mgr.project_id = "jse-proj"
+    mgr.dataset = "financials"
+    mgr.table = "statements"
+    return mgr
+
+
+@pytest.mark.unit
+class TestDescribeSource:
+    def test_source_is_typed_dataset(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 0)
+        assert source.type == SourceType.DATASET
+
+    def test_table_is_fully_qualified(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 3)
+        assert source.table == "jse-proj.financials.statements"
+
+    def test_record_count_is_carried(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 42)
+        assert source.record_count == 42
+
+    def test_only_query_shaping_filters_are_included(self, manager):
+        """Conversational fields describe interpretation, not what was read."""
+        filters = FinancialDataFilters(
+            companies=["NCB Financial Group"],
+            symbols=["NCBFG"],
+            years=["2023"],
+            standard_items=["net_profit"],
+            interpretation="user wants NCB net profit",
+            is_follow_up=True,
+            context_used="previous turn",
+            data_availability_note="note",
+            unrecognized_items=["ebitda"],
+        )
+        source = manager.describe_source(filters, 4)
+        assert source.filters == {
+            "companies": ["NCB Financial Group"],
+            "symbols": ["NCBFG"],
+            "years": ["2023"],
+            "standard_items": ["net_profit"],
+        }
+
+    def test_title_names_the_dataset_readably(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 1)
+        assert source.title
+        assert "jse-proj" not in source.title  # a title, not a table id
+
+    def test_retrieved_at_is_populated(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 1)
+        assert source.retrieved_at is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_dataset_source.py -v --no-cov`
+Expected: FAIL with `AttributeError: 'FinancialDataManager' object has no attribute 'describe_source'`
+
+- [ ] **Step 3: Add `describe_source` to `FinancialDataManager`**
+
+In `app/financial_utils.py`, add the import and the method (place it next to `query_data`, around line 891):
+
+```python
+from datetime import datetime, timezone
+
+from app.models import Source, SourceType
+```
+
+```python
+    def describe_source(self, filters: FinancialDataFilters, record_count: int) -> Source:
+        """Describe the dataset read for this answer.
+
+        Honest provenance for a financial figure is the table plus the filters
+        applied. The table carries no reference to the statement PDF a figure
+        was extracted from, so this deliberately stops at the query rather than
+        implying a document-level citation it cannot support.
+        """
+        return Source(
+            type=SourceType.DATASET,
+            title="JSE financial statements dataset",
+            detail="Figures read directly from the JSE financial statements table",
+            table=f"{self.project_id}.{self.dataset}.{self.table}",
+            filters={
+                "companies": list(filters.companies or []),
+                "symbols": list(filters.symbols or []),
+                "years": list(filters.years or []),
+                "standard_items": list(filters.standard_items or []),
+            },
+            record_count=record_count,
+            retrieved_at=datetime.now(timezone.utc).isoformat(),
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_dataset_source.py -v --no-cov`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Wire sources into `/fast_chat_v2`**
+
+In `app/main.py`, after the chart generation block (line ~698) add:
+
+```python
+            sources = (
+                [financial_manager.describe_source(filters, len(results))] if results else None
+            )
+```
+
+Add to the cache payload written at line 707:
+
+```python
+                    "sources": _jsonable(sources),
+```
+
+Add to the returned `FinancialDataResponse` at line 734:
+
+```python
+            sources=sources,
+```
+
+And in the cache-hit branch (line 631), add:
+
+```python
+                sources=cached.get("sources"),
+```
+
+- [ ] **Step 6: Write the cache round-trip test**
+
+Append to `fastapi_app/tests/unit/test_dataset_source.py`:
+
+```python
+@pytest.mark.unit
+class TestSourceCacheRoundTrip:
+    def test_source_survives_json_round_trip(self, manager):
+        """Sources go through Redis as JSON; nothing in them may be unserializable."""
+        import json
+
+        from app.main import _jsonable
+        from app.models import Source
+
+        source = manager.describe_source(
+            FinancialDataFilters(companies=["NCB"], years=["2023"]), 5
+        )
+        payload = json.loads(json.dumps(_jsonable([source])))
+        restored = [Source(**item) for item in payload]
+        assert restored[0].table == source.table
+        assert restored[0].filters == source.filters
+        assert restored[0].record_count == 5
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_dataset_source.py -v --no-cov`
+Expected: PASS (7 tests)
+
+- [ ] **Step 8: Verify no regression**
+
+Run: `python -m pytest tests/unit tests/test_financial_utils.py tests/test_api.py -v --no-cov`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add fastapi_app/app/financial_utils.py fastapi_app/app/main.py fastapi_app/tests/unit/test_dataset_source.py
+git commit -m "feat(financial): return dataset provenance from /fast_chat_v2"
+```
+
+---
+
+### Task 6: Fix the test client's source rendering
+
+**Files:**
+- Modify: `mock_client/chat_assistant_test_client.html:943-945`
+
+**Interfaces:**
+- Consumes: the `Source` JSON shape from Tasks 1, 2, 4, 5.
+- Produces: nothing consumed by later tasks.
+
+The client reads `s.description` — a key the API has never emitted — so its source display has always been blank. There is no automated test for the mock client; verification is by eye in Task 7.
+
+- [ ] **Step 1: Replace the renderer**
+
+Replace lines 943–945:
+
+```javascript
+      if (data.sources?.length) {
+        const sourcesList = data.sources.map(s => {
+          const label = s.title || s.domain || s.table || 'source';
+          if (s.type === 'web' && s.url) return `<a href="${s.url}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+          if (s.type === 'document' && s.document_id) return `<a href="${baseUrl}/documents/${s.document_id}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+          if (s.type === 'dataset') return `${label}${s.record_count != null ? ` (${s.record_count} rows)` : ''}`;
+          return label;
+        }).join(', ');
+        extraDetails.push(`Sources: ${sourcesList}`);
+      }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add mock_client/chat_assistant_test_client.html
+git commit -m "fix(mock-client): render the real Source schema instead of a nonexistent key"
+```
+
+---
+
+### Task 7: Full local verification — no-regression gate
+
+**Files:** none modified. This task produces evidence, not code.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–6.
+- Produces: a verified, regression-free branch.
+
+**Do not report this work as complete until every step below has been run and its actual output inspected.** A step that fails is a bug to fix, not a note to append.
+
+- [ ] **Step 1: Re-read the baseline captured in Task 0**
+
+```bash
+tail -20 fastapi_app/baseline-tests.txt
+```
+
+This is the pre-change pass/fail state. If the file is missing, Task 0 was skipped — go back and run it against `origin/main` in a scratch worktree, because the current branch can no longer produce an honest baseline.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `python -m pytest tests -v --no-cov`
+Expected: PASS. Compare the failure set against Task 0's baseline — it must be identical or smaller. **Any test that passed in the baseline and fails now blocks this task**, regardless of whether it looks related to this work.
+
+- [ ] **Step 3: Run linting and formatting**
+
+```bash
+python -m ruff check app tests && python -m black --check app tests
+```
+
+Expected: clean. Fix anything reported, then re-run.
+
+- [ ] **Step 4: Confirm the OpenAPI schema builds**
+
+A malformed response model breaks schema generation without failing any unit test:
+
+```bash
+python -c "from app.main import app; s = app.openapi(); assert 'Source' in s['components']['schemas']; print('Source schema OK'); print(sorted(s['paths']))"
+```
+
+Expected: `Source schema OK` and `/documents/{document_id}` present in the path list.
+
+- [ ] **Step 5: Smoke-test the running app**
+
+REQUIRED SUB-SKILL: use the `run-local-smoke-test` skill to launch the app and drive it. It covers the `.env`-in-worktree gotcha and the Windows shutdown steps.
+
+Verify by inspecting actual response bodies, not just status codes:
+- `GET /health` returns 200.
+- `POST /chat/stream` with `{"query": "What was NCB's net profit in 2023?"}` returns a non-empty `sources` array whose entries have `type: "web"`, a `title`, and a `url`.
+- `POST /fast_chat_v2` with the same query returns a `sources` array containing one `dataset` entry with a fully-qualified `table` and a `record_count` matching `record_count` at the top level.
+- `POST /chat` with a document-shaped query returns `sources` entries of `type: "document"` each carrying a `document_id`, and `documents_loaded` still populated.
+- `GET /documents/{document_id}` using an id from that response returns a 307 whose `Location` is an S3 presigned URL.
+- `GET /documents/0000000000000000` returns 404.
+
+- [ ] **Step 6: Verify the cache path specifically**
+
+Cached responses are the most likely place for this feature to break, because sources must survive a JSON round-trip through Redis. With the app running, issue the **same** `/fast_chat_v2` query twice with no conversation history. Confirm the second response is a cache hit (check the logs for `cache hit`) and that its `sources` array is identical to the first. Repeat for `/chat/stream`.
+
+- [ ] **Step 7: Verify the test client by eye**
+
+Open `mock_client/chat_assistant_test_client.html` against the local server and confirm the Sources line renders real, clickable entries in all three modes — not blank, and not `[object Object]`.
+
+- [ ] **Step 8: Report results honestly**
+
+State the actual test counts, any pre-existing failures carried over from the Step 1 baseline, and anything not verified. If a step could not be run (no AWS credentials, no Redis), say so explicitly rather than implying it passed.
+
+- [ ] **Step 9: Commit any fixes**
+
+Stage explicitly — `git add -A` would sweep in `baseline-tests.txt`:
+
+```bash
+git add fastapi_app/app fastapi_app/tests mock_client
+git commit -m "test: verify sources feature end-to-end with no regressions"
+```
+
+- [ ] **Step 10: Clean up the scratch baseline**
+
+```bash
+rm -f fastapi_app/baseline-tests.txt && git status --short
+```
+
+Expected: a clean tree.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| `Source` model + `SourceType` | 1 |
+| Response model changes (3 models) | 1 |
+| `retrieved_at` semantics | 2, 4, 5 (set at retrieval time in each producer) |
+| Backward compatibility | 1 (test), 4 (`documents_loaded` retained) |
+| `/chat/stream` wiring + dedupe + `domain` | 2 |
+| `/fast_chat_v2` wiring + cache payload + filter subset | 5 |
+| `/chat` wiring + `DocumentLoadResult` + 7 call sites | 4 |
+| Document resolver + non-forgeable id + 5-min TTL | 3 |
+| Test client fix | 6 |
+| Testing section (builders, dedupe, resolver 404, cache round-trip, back-compat) | 1, 2, 3, 4, 5 |
+| Known limitation (no statement-page citation) | 5 (documented in `describe_source` docstring) |
+
+**Not in the spec, added here:**
+- The `_jsonable` fix at `main.py:1013` (Task 1, Step 5). Without it, changing `sources` to a typed model breaks the `/chat/stream` Redis write — a regression the spec did not anticipate.
+- Task 0 (baseline capture) and Task 7 (verification gate), per the requirement that no regression be introduced locally before this is called done.
+
+**Known-broken code deliberately left alone:** `POST /cache/refresh` calls `load_metadata_from_s3()` with no arguments while the function requires `s3_client` (`main.py:806`), so it raises `TypeError` on every call. Pre-existing and unrelated; tracked separately. It is the reason the document index is built in `lifespan` (Task 3, Step 7) rather than hung off that endpoint — but note that until it is fixed, a metadata refresh will not rebuild the document index.
+
+**Type consistency:** `Source` / `SourceType` field names are identical across Tasks 1–5. `DocumentLoadResult` uses `.texts` / `.message` / `.loaded_docs` / `.sources` in Task 4's definition and at every call site. `make_document_id` has one signature, used in Tasks 3 and 4. `describe_source(filters, record_count)` matches its call in Task 5, Step 5.

--- a/docs/superpowers/specs/2026-08-17-response-sources-provenance-design.md
+++ b/docs/superpowers/specs/2026-08-17-response-sources-provenance-design.md
@@ -1,0 +1,252 @@
+# Response Sources & Provenance
+
+**Date:** 2026-08-17
+**Status:** Design — approved approach, pending spec review
+
+## Context
+
+A request came in to return the sources each endpoint used to answer a query.
+Users need this to fact-check answers; the UI needs it to render a citations
+panel.
+
+The feature is roughly a quarter built today, and only on one endpoint.
+
+| Endpoint | Answers from | Provenance returned today |
+|---|---|---|
+| `/chat/stream` (AgentV2) | Gemini 2.5 Pro + Google Search grounding | `sources: [{type, title, url}]` and `web_search_results` |
+| `/fast_chat_v2` | BigQuery financial table | None — only `data_preview` and `filters_used` |
+| `/chat` | PDFs in S3 | Filenames only (`documents_loaded`), no URLs, no pages |
+
+### Facts about the current code
+
+- `AgentChatResponse.sources` is typed `Optional[List[Dict[str, Any]]]`
+  ([`models.py:253`](../../../fastapi_app/app/models.py)). There is no schema, so
+  the UI cannot rely on any key being present.
+- The only producer is `AgentV2._extract_grounding_metadata`
+  ([`agent_v2.py:268`](../../../fastapi_app/app/agent_v2.py)), which emits
+  `{type: "web", title, url}` per grounding chunk. It does not dedupe, and
+  Gemini repeats the same chunk across grounding supports — so the list
+  currently contains duplicates.
+- Gemini's grounding URIs are `vertexaisearch.cloud.google.com` redirects that
+  expire in roughly 30 days.
+- `grounding_supports` (Gemini's per-claim segment→chunk mapping) is available on
+  the response and is currently discarded. It is **not** used in this design; see
+  "Rejected alternatives".
+- `FinancialDataResponse` and `ChatResponse` have no `sources` field at all.
+- Documents are private `s3://bucket/key` paths. There is no presigned-URL
+  support anywhere in the codebase
+  ([`s3_client.py:58`](../../../fastapi_app/app/s3_client.py)).
+- `auto_load_relevant_documents`
+  ([`document_selector.py:479`](../../../fastapi_app/app/document_selector.py))
+  has `doc_info` with `document_link` and `reason` in scope but returns only
+  filenames.
+- Both `/fast_chat_v2` and `/chat/stream` cache responses in Redis.
+  `/chat/stream` already persists `sources` in its cache payload
+  ([`main.py:1013`](../../../fastapi_app/app/main.py)); `/fast_chat_v2` has no
+  sources to persist yet.
+- [`mock_client/chat_assistant_test_client.html:944`](../../../mock_client/chat_assistant_test_client.html)
+  renders sources by reading `s.description` — a key the API has never emitted.
+  The test client's source display has therefore always been blank.
+
+## Decisions
+
+Settled during brainstorming:
+
+1. **All three endpoints** return sources, not just `/chat/stream`.
+2. **Flat source list** per response, not inline per-claim citations.
+3. **Opaque document id plus a resolver endpoint**, not inline presigned URLs.
+4. **One polymorphic `sources` array** with a `type` discriminator, not separate
+   per-type arrays and not a strict discriminated union.
+
+## Design
+
+### The `Source` model
+
+Added to [`models.py`](../../../fastapi_app/app/models.py):
+
+```python
+class SourceType(str, Enum):
+    WEB = "web"            # Google Search grounding chunk
+    DOCUMENT = "document"  # PDF in S3
+    DATASET = "dataset"    # BigQuery financial table
+
+
+class Source(BaseModel):
+    type: SourceType
+    title: str                            # always present, always human-readable
+    detail: Optional[str] = None          # why this source was used
+    retrieved_at: Optional[str] = None    # ISO 8601 timestamp
+
+    # web
+    url: Optional[str] = None             # Gemini redirect URI — expires (~30d)
+    domain: Optional[str] = None          # e.g. "jamstockex.com"
+
+    # document
+    document_id: Optional[str] = None     # resolve via GET /documents/{id}
+    company: Optional[str] = None
+    year: Optional[str] = None
+
+    # dataset
+    table: Optional[str] = None           # "project.dataset.table"
+    filters: Optional[Dict[str, Any]] = None
+    record_count: Optional[int] = None
+```
+
+`type` and `title` are the only required fields. A client that understands
+nothing else can always render a meaningful citation line.
+
+`retrieved_at` is the time the underlying retrieval ran, not the time the
+response was serialized: the Gemini call for web sources, the BigQuery query for
+dataset sources, the S3 fetch for document sources. On a cache hit it is
+replayed from the cached payload, so it correctly reports when the data was
+actually fetched rather than when it was re-served.
+
+For dataset sources, `filters` carries the four query-shaping fields from
+`FinancialDataFilters` — `companies`, `symbols`, `years`, `standard_items`. The
+conversational fields (`interpretation`, `is_follow_up`, `context_used`,
+`data_availability_note`, `unrecognized_items`) are excluded: they describe how
+the query was understood, not which data was read, and `filters_used` already
+carries the full object for clients that want them.
+
+### Response model changes
+
+- `AgentChatResponse.sources` changes type from `Optional[List[Dict[str, Any]]]`
+  to `Optional[List[Source]]`. The serialized JSON for a web source is
+  unchanged.
+- `FinancialDataResponse` gains `sources: Optional[List[Source]] = None`.
+- `ChatResponse` gains `sources: Optional[List[Source]] = None`.
+
+Two choices that are load-bearing:
+
+- **`domain` is not redundant with `url`.** Grounding URIs expire. When the link
+  dies, `domain` plus `title` still tells the user who said it — the citation
+  degrades to text rather than to nothing. The alternative, resolving each
+  redirect to its publisher URL, costs an HTTP round-trip per source on the hot
+  path and is not worth it.
+- **Dataset sources cite the query, not a row.** Honest provenance for
+  `/fast_chat_v2` is "this came from `<table>`, filtered to NCBFG / 2023 /
+  net_profit, 4 rows matched". Both `filters` and `record_count` are already
+  computed; this only surfaces them.
+
+### Backward compatibility
+
+Today's web sources emit `{type, title, url}`. All three fields survive
+unchanged, and everything else is additive, so existing consumers keep working.
+`documents_loaded` on `ChatResponse` is retained alongside the new `sources`
+field for the same reason.
+
+### Per-endpoint wiring
+
+**`/chat/stream`** — `_extract_grounding_metadata` builds `Source` objects
+instead of raw dicts. Two fixes land with it:
+
+- Dedupe chunks by URL.
+- Populate `domain` from `web.domain`, falling back to `web.title` (the SDK puts
+  the site domain in `title` for most chunks).
+
+The refusal fast path continues to return `sources=None`.
+
+**`/fast_chat_v2`** — add `sources` to `FinancialDataResponse`. After
+`query_data`, build a single dataset `Source` from the table identity on
+`FinancialDataManager` (its `project_id` / `dataset` / `table` env config), the
+applied `filters`, and `len(results)`. Add `sources` to the Redis cache payload
+at [`main.py:707`](../../../fastapi_app/app/main.py) — cache-safe, because
+nothing in a dataset source expires.
+
+**`/chat`** — add `sources` to `ChatResponse`, keeping `documents_loaded`.
+
+`auto_load_relevant_documents` must return the document metadata it currently
+discards. It already returns a 3-tuple and now needs a 4th value, so its return
+type changes to a small `DocumentLoadResult` dataclass with fields `texts`,
+`message`, `loaded_docs`, and `sources`. Growing the tuple instead would break
+the same call sites (tuple unpacking fails on any arity change), so the readable
+option wins at equal cost.
+
+Seven call sites are updated. Five unpack the tuple directly
+([`main.py:477`](../../../fastapi_app/app/main.py),
+`_archive/streaming_chat.py:166`, `tests/test_async_s3_downloads.py:407` and
+`:455`, `test_async_integration.py:149`). Two assert its arity explicitly —
+`tests/unit/test_document_selector.py:53` and `:64` both check
+`len(result) == 3` — and become assertions on the dataclass fields instead.
+
+The same change is applied to `auto_load_relevant_documents_async`. That
+function is used only by archived code and tests today, but letting the pair
+diverge is how it rots.
+
+### Document resolver endpoint
+
+```
+GET /documents/{document_id}  →  307 redirect to a presigned S3 URL
+```
+
+- Presigned URL TTL: 5 minutes.
+- Backed by a `{document_id: s3_path}` index built once when `metadata.json`
+  loads.
+- `document_id = sha256(s3_path)[:16]`.
+- Unknown id → `404`.
+
+**The id must not be a reversible encoding of the S3 path.** A base64'd
+`s3://bucket/key` would let a client edit the id and read arbitrary objects from
+the bucket through our own resolver. Because the id is a lookup key rather than
+a decodable path, there is no input a client can craft to reach an object
+outside `metadata.json`.
+
+This indirection is also what makes sources cacheable: a presigned URL baked
+into a Redis-cached response would be dead by the time it was served.
+
+### Test client fix
+
+Update [`chat_assistant_test_client.html`](../../../mock_client/chat_assistant_test_client.html)
+to render the real schema (`type`, `title`, `url`/`document_id`) instead of the
+non-existent `description` key.
+
+## Testing
+
+- Unit tests per source builder: grounding chunk → `Source`, filters → `Source`,
+  `doc_info` → `Source`.
+- Grounding dedupe: repeated chunks for one URL yield one source.
+- Resolver: a tampered or unknown `document_id` returns `404` and never a
+  presigned URL.
+- Cache round-trip: sources survive Redis on both `/chat/stream` and
+  `/fast_chat_v2`.
+- Backward compatibility: a web source still serializes with `type`, `title`,
+  and `url`.
+
+Tests follow the existing layout under `fastapi_app/tests/unit/`.
+
+## Known limitation: financial figures cannot cite a statement page
+
+The BigQuery table has no column referencing the PDF a figure was extracted
+from. `query_data` selects `Company, Symbol, Year, standard_item, item,
+unit_multiplier, item_type, item_name`
+([`financial_utils.py:897`](../../../fastapi_app/app/financial_utils.py)) and
+that is all the table holds.
+
+So a `/fast_chat_v2` answer can cite the table and the filters, but it cannot
+hand a user the statement page a number came from — which is the strongest form
+of fact-checking for financial figures. Closing this requires adding a
+source-document reference upstream in the extraction pipeline, which is separate
+work and out of scope here.
+
+This is recorded rather than papered over, so the dataset citation does not
+imply more provenance than it has.
+
+## Rejected alternatives
+
+**Separate typed arrays** (`web_sources`, `document_sources`, `data_sources`) —
+cleaner typing with no optional-field soup, but the UI must merge three lists to
+render one citations panel, and it orphans the existing `sources` field.
+
+**Strict discriminated union** (Pydantic `Field(discriminator=...)`) — best
+OpenAPI output (`oneOf`), but adding a fourth source type later becomes a
+breaking change for strictly-validating clients.
+
+**Inline per-claim citations** using `grounding_supports` — genuine
+fact-checking, but the char offsets Gemini returns are fragile, and neither the
+financial nor the document path has an equivalent, so those would have to be
+synthesized. The `Source` schema leaves room to add per-claim spans additively
+later.
+
+**Resolving grounding redirects to publisher URLs** — fixes link expiry, but
+costs an HTTP round-trip per source on the hot path. `domain` covers the
+degraded case at no latency cost.

--- a/fastapi_app/app/_archive/streaming_chat.py
+++ b/fastapi_app/app/_archive/streaming_chat.py
@@ -162,17 +162,18 @@ async def _process_traditional_chat(
                     await tracker.emit_progress("doc_loading", message, progress)
 
                 # Use async document loading with progress tracking
-                document_texts, document_selection_message, loaded_docs = (
-                    await auto_load_relevant_documents_async(
-                        query=request.query,
-                        metadata=metadata,
-                        conversation_history=request.conversation_history,
-                        current_document_texts={},  # Start with empty document_texts since this is stateless
-                        config=download_config,
-                        progress_callback=download_progress_callback,
-                        associations=associations,
-                    )
+                load_result = await auto_load_relevant_documents_async(
+                    query=request.query,
+                    metadata=metadata,
+                    conversation_history=request.conversation_history,
+                    current_document_texts={},  # Start with empty document_texts since this is stateless
+                    config=download_config,
+                    progress_callback=download_progress_callback,
+                    associations=associations,
                 )
+                document_texts = load_result.texts
+                document_selection_message = load_result.message
+                loaded_docs = load_result.loaded_docs
 
                 await tracker.emit_progress(
                     "doc_loading",

--- a/fastapi_app/app/agent_v2.py
+++ b/fastapi_app/app/agent_v2.py
@@ -13,6 +13,7 @@ Architecture:
 """
 
 import asyncio
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from google.genai import types
@@ -20,7 +21,7 @@ from google.genai import types
 from app.document_selector import extract_companies_from_query
 from app.gemini_client import get_genai_client
 from app.logging_config import get_logger
-from app.models import CostSummary, PhaseCost
+from app.models import CostSummary, PhaseCost, Source, SourceType
 from app.tracing import log_completed_generation
 from app.utils.cost_tracking import calculate_cost_from_response
 from app.utils.monitoring import record_ai_cost
@@ -293,28 +294,39 @@ class AgentV2:
             if hasattr(sep, "rendered_content"):
                 search_results["search_entry_point"] = sep.rendered_content
 
-        # Extract grounding chunks (web sources)
+        # Extract grounding chunks (web sources).
+        # Gemini emits one chunk per grounding support, so the same URL can
+        # appear many times — dedupe while preserving first-seen order.
         chunks = getattr(grounding, "grounding_chunks", []) or []
         grounding_chunks = []
+        retrieved_at = datetime.now(timezone.utc).isoformat()
+        seen_urls = set()
 
         for chunk in chunks:
-            if hasattr(chunk, "web") and chunk.web:
-                web = chunk.web
-                chunk_info = {
-                    "title": getattr(web, "title", ""),
-                    "uri": getattr(web, "uri", ""),
-                }
-                grounding_chunks.append(chunk_info)
+            if not (hasattr(chunk, "web") and chunk.web):
+                continue
+            web = chunk.web
+            uri = getattr(web, "uri", "") or ""
+            title = getattr(web, "title", "") or ""
+            grounding_chunks.append({"title": title, "uri": uri})
 
-                # Add to sources list
-                if chunk_info["uri"]:
-                    sources.append(
-                        {
-                            "type": "web",
-                            "title": chunk_info["title"],
-                            "url": chunk_info["uri"],
-                        }
-                    )
+            if not uri or uri in seen_urls:
+                continue
+            seen_urls.add(uri)
+
+            # Newer SDKs expose web.domain; older ones put the site domain in
+            # web.title. Either way the citation stays readable once the
+            # redirect URI expires.
+            domain = getattr(web, "domain", None) or title or None
+            sources.append(
+                Source(
+                    type=SourceType.WEB,
+                    title=title or domain or uri,
+                    url=uri,
+                    domain=domain,
+                    retrieved_at=retrieved_at,
+                )
+            )
 
         if grounding_chunks:
             search_results["grounding_chunks"] = grounding_chunks

--- a/fastapi_app/app/document_registry.py
+++ b/fastapi_app/app/document_registry.py
@@ -1,10 +1,13 @@
-"""Stable, non-forgeable identifiers for the S3 documents we cite.
+"""Stable, non-reversible, index-bounded identifiers for the S3 documents we cite.
 
 A cited document is exposed to clients as an opaque `document_id`, never as
-an S3 path. The id is a truncated SHA-256 of the path and is resolved by a
-dict lookup built from metadata.json, so a client cannot craft an id that
-reaches an object we did not index. Presigned URLs are minted per request
-and never cached, so a cached response can never hand out a dead link.
+an S3 path. The id is a truncated SHA-256 of the path, so it cannot be
+decoded back to a path (non-reversible); it is not a secret, since anyone
+who guesses or already knows the S3 path can compute the same id offline.
+The safety property comes from resolution: an id is redeemed by a dict
+lookup built from metadata.json, so no crafted input can reach an object we
+did not index (index-bounded). Presigned URLs are minted per request and
+never cached, so a cached response can never hand out a dead link.
 """
 
 import hashlib

--- a/fastapi_app/app/document_registry.py
+++ b/fastapi_app/app/document_registry.py
@@ -1,0 +1,76 @@
+"""Stable, non-forgeable identifiers for the S3 documents we cite.
+
+A cited document is exposed to clients as an opaque `document_id`, never as
+an S3 path. The id is a truncated SHA-256 of the path and is resolved by a
+dict lookup built from metadata.json, so a client cannot craft an id that
+reaches an object we did not index. Presigned URLs are minted per request
+and never cached, so a cached response can never hand out a dead link.
+"""
+
+import hashlib
+from typing import Any, Dict, Optional, Tuple
+
+from app.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+DOCUMENT_ID_LENGTH = 16
+PRESIGNED_URL_TTL_SECONDS = 300
+
+
+def make_document_id(s3_path: str) -> str:
+    """Derive a stable, one-way id for an S3 path."""
+    return hashlib.sha256(s3_path.encode("utf-8")).hexdigest()[:DOCUMENT_ID_LENGTH]
+
+
+def parse_s3_path(s3_path: str) -> Tuple[str, str]:
+    """Split an ``s3://bucket/key`` path into ``(bucket, key)``."""
+    if not s3_path or not s3_path.startswith("s3://"):
+        raise ValueError(f"Not an s3:// path: {s3_path!r}")
+    remainder = s3_path[len("s3://") :]
+    bucket, _, key = remainder.partition("/")
+    if not bucket or not key:
+        raise ValueError(f"S3 path is missing a bucket or key: {s3_path!r}")
+    return bucket, key
+
+
+def build_document_index(metadata: Optional[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Map document_id -> resolution info for every document in S3 metadata.
+
+    Metadata is shaped ``{company_name: [document, ...]}``. It is loaded from
+    S3 at startup, so a malformed shape is tolerated rather than fatal.
+    """
+    index: Dict[str, Dict[str, Any]] = {}
+    if not metadata or not isinstance(metadata, dict):
+        return index
+
+    for company, documents in metadata.items():
+        if not isinstance(documents, list):
+            continue
+        for doc in documents:
+            if not isinstance(doc, dict):
+                continue
+            s3_path = doc.get("document_link")
+            if not s3_path:
+                continue
+            index[make_document_id(s3_path)] = {
+                "s3_path": s3_path,
+                "filename": doc.get("filename") or s3_path.rsplit("/", 1)[-1],
+                "company": company,
+                "year": doc.get("year") or doc.get("period"),
+            }
+
+    logger.info(f"Document index built: {len(index)} documents")
+    return index
+
+
+def presign_document(
+    s3_client: Any, s3_path: str, expires_in: int = PRESIGNED_URL_TTL_SECONDS
+) -> str:
+    """Mint a short-lived presigned GET URL for a document."""
+    bucket, key = parse_s3_path(s3_path)
+    return s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=expires_in,
+    )

--- a/fastapi_app/app/document_selector.py
+++ b/fastapi_app/app/document_selector.py
@@ -8,13 +8,17 @@ and supports both synchronous and asynchronous document loading operations.
 import asyncio
 import json
 import time
-from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
 
 from google.genai import types
 
 from app.config import S3DownloadConfig, get_config
+from app.document_registry import make_document_id
 from app.gemini_client import get_genai_client
 from app.logging_config import get_logger
+from app.models import Source, SourceType
 from app.s3_client import (
     DownloadResult,
     download_and_extract_from_s3,
@@ -23,6 +27,20 @@ from app.s3_client import (
 from app.utils.monitoring import record_document_load, record_document_selection
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class DocumentLoadResult:
+    """What a document-loading pass produced.
+
+    Replaces the old 3-tuple: callers needed a fourth value (`sources`), and
+    growing the tuple would have broken every unpacking site anyway.
+    """
+
+    texts: Dict[str, str]
+    message: str
+    loaded_docs: List[str] = field(default_factory=list)
+    sources: List[Source] = field(default_factory=list)
 
 
 # =============================================================================
@@ -497,63 +515,85 @@ def auto_load_relevant_documents(
     """
     document_texts = current_document_texts.copy() if current_document_texts else {}
     loaded_docs = []
+    sources: List[Source] = []
 
     # Use two-stage LLM approach to determine which documents to load
     recommendation = semantic_document_selection(
         query, metadata, conversation_history, associations
     )
 
-    if recommendation and "documents_to_load" in recommendation:
-        docs_to_load = recommendation["documents_to_load"]
+    if not recommendation or "documents_to_load" not in recommendation:
+        return DocumentLoadResult(
+            texts=document_texts,
+            message="No relevant documents were identified for your query.",
+        )
 
-        # Load the recommended documents (limited to 3)
-        for doc_info in docs_to_load[:3]:
-            doc_link = doc_info["document_link"]
-            doc_name = doc_info["filename"]
+    docs_to_load = recommendation["documents_to_load"]
 
-            # Only load if not already loaded
-            if doc_name not in document_texts:
-                load_start = time.time()
-                try:
-                    text = download_and_extract_from_s3(s3_client, doc_link)
-                    load_duration = time.time() - load_start
-                    if text:
-                        document_texts[doc_name] = text
-                        loaded_docs.append(doc_name)
-                        # Record successful document load from S3
-                        record_document_load(source="s3", duration=load_duration, success=True)
-                    else:
-                        # Record failed document load
-                        record_document_load(source="error", duration=load_duration, success=False)
-                except Exception as e:
-                    load_duration = time.time() - load_start
-                    # Record failed document load
-                    record_document_load(source="error", duration=load_duration, success=False)
-                    logger.error(
-                        "document_load_failed",
-                        extra={
-                            "document": doc_name,
-                            "error": str(e),
-                            "error_type": type(e).__name__,
-                        },
+    # Load the recommended documents (limited to 3)
+    for doc_info in docs_to_load[:3]:
+        doc_link = doc_info["document_link"]
+        doc_name = doc_info["filename"]
+
+        # Only load if not already loaded
+        if doc_name in document_texts:
+            continue
+
+        load_start = time.time()
+        try:
+            text = download_and_extract_from_s3(s3_client, doc_link)
+            load_duration = time.time() - load_start
+            if text:
+                document_texts[doc_name] = text
+                loaded_docs.append(doc_name)
+                # Only cite a document we actually read.
+                sources.append(
+                    Source(
+                        type=SourceType.DOCUMENT,
+                        title=doc_name,
+                        detail=doc_info.get("reason"),
+                        document_id=make_document_id(doc_link),
+                        company=doc_info.get("company"),
+                        year=doc_info.get("year") or doc_info.get("period"),
+                        retrieved_at=datetime.now(timezone.utc).isoformat(),
                     )
-
-        # Generate message about what was loaded
-        if loaded_docs:
-            message = f"Semantically selected {len(loaded_docs)} documents based on your query:\n"
-            for doc_name in loaded_docs:
-                matching_doc = next((d for d in docs_to_load if d["filename"] == doc_name), None)
-                if matching_doc:
-                    message += f"• {doc_name} - {matching_doc.get('reason', '')}\n"
-            return document_texts, message, loaded_docs
-        else:
-            return (
-                document_texts,
-                "No documents were loaded. Please check S3 access permissions or document availability.",
-                [],
+                )
+                record_document_load(source="s3", duration=load_duration, success=True)
+            else:
+                record_document_load(source="error", duration=load_duration, success=False)
+        except Exception as e:
+            load_duration = time.time() - load_start
+            record_document_load(source="error", duration=load_duration, success=False)
+            logger.error(
+                "document_load_failed",
+                extra={
+                    "document": doc_name,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
             )
 
-    return document_texts, "No relevant documents were identified for your query.", []
+    if not loaded_docs:
+        return DocumentLoadResult(
+            texts=document_texts,
+            message=(
+                "No documents were loaded. Please check S3 access permissions "
+                "or document availability."
+            ),
+        )
+
+    message = f"Semantically selected {len(loaded_docs)} documents based on your query:\n"
+    for doc_name in loaded_docs:
+        matching_doc = next((d for d in docs_to_load if d["filename"] == doc_name), None)
+        if matching_doc:
+            message += f"• {doc_name} - {matching_doc.get('reason', '')}\n"
+
+    return DocumentLoadResult(
+        texts=document_texts,
+        message=message,
+        loaded_docs=loaded_docs,
+        sources=sources,
+    )
 
 
 # =============================================================================
@@ -569,7 +609,7 @@ async def auto_load_relevant_documents_async(
     config: Optional[S3DownloadConfig] = None,
     progress_callback: Optional[callable] = None,
     associations: Optional[Dict] = None,
-) -> Tuple[Dict[str, str], str, List[str]]:
+) -> DocumentLoadResult:
     """
     Asynchronously load relevant documents based on query and conversation history with concurrent downloads.
 
@@ -583,13 +623,15 @@ async def auto_load_relevant_documents_async(
         associations: Optional dict with 'symbol_to_company' mapping for better resolution
 
     Returns:
-        Tuple of (document_texts, message, loaded_docs)
+        DocumentLoadResult with the loaded texts, a status message, the loaded
+        filenames, and the citable Source objects.
     """
     if config is None:
         config = get_config().s3_download
 
     document_texts = current_document_texts.copy() if current_document_texts else {}
     loaded_docs = []
+    sources: List[Source] = []
 
     try:
         if progress_callback:
@@ -606,7 +648,7 @@ async def auto_load_relevant_documents_async(
             message = "No relevant documents were identified for your query."
             if progress_callback:
                 await progress_callback("document_selection_complete", message)
-            return document_texts, message, []
+            return DocumentLoadResult(texts=document_texts, message=message)
 
         docs_to_load = recommendation["documents_to_load"]
         companies_mentioned = recommendation.get("companies_mentioned", [])
@@ -630,7 +672,7 @@ async def auto_load_relevant_documents_async(
             message = "All relevant documents are already loaded."
             if progress_callback:
                 await progress_callback("documents_already_loaded", message)
-            return document_texts, message, []
+            return DocumentLoadResult(texts=document_texts, message=message)
 
         if progress_callback:
             await progress_callback(
@@ -669,6 +711,18 @@ async def auto_load_relevant_documents_async(
                     document_texts[doc_name] = result.content
                     loaded_docs.append(doc_name)
                     successful_downloads += 1
+                    # Only cite a document we actually read.
+                    sources.append(
+                        Source(
+                            type=SourceType.DOCUMENT,
+                            title=doc_name,
+                            detail=doc_info.get("reason"),
+                            document_id=make_document_id(doc_info["document_link"]),
+                            company=doc_info.get("company"),
+                            year=doc_info.get("year") or doc_info.get("period"),
+                            retrieved_at=datetime.now(timezone.utc).isoformat(),
+                        )
+                    )
                     # Record successful async document load from S3
                     record_document_load(source="s3", duration=result.download_time, success=True)
                     logger.info(
@@ -709,7 +763,12 @@ async def auto_load_relevant_documents_async(
                 f"Completed: {successful_downloads} successful, {failed_downloads} failed",
             )
 
-        return document_texts, message, loaded_docs
+        return DocumentLoadResult(
+            texts=document_texts,
+            message=message,
+            loaded_docs=loaded_docs,
+            sources=sources,
+        )
 
     except Exception as e:
         error_msg = f"Error in async document loading: {str(e)}"
@@ -723,7 +782,7 @@ async def auto_load_relevant_documents_async(
         )
         if progress_callback:
             await progress_callback("document_load_error", error_msg)
-        return document_texts, error_msg, []
+        return DocumentLoadResult(texts=document_texts, message=error_msg)
 
 
 async def _download_single_document_async(

--- a/fastapi_app/app/document_selector.py
+++ b/fastapi_app/app/document_selector.py
@@ -43,6 +43,23 @@ class DocumentLoadResult:
     sources: List[Source] = field(default_factory=list)
 
 
+def _build_document_source(doc_name: str, doc_link: str, doc_info: Dict) -> Source:
+    """Build the citable Source for a document that was just read successfully.
+
+    Shared by the sync and async loaders so their citation fields (and any
+    future fix to how document_id or provenance is derived) can't drift apart.
+    """
+    return Source(
+        type=SourceType.DOCUMENT,
+        title=doc_name,
+        detail=doc_info.get("reason"),
+        document_id=make_document_id(doc_link),
+        company=doc_info.get("company"),
+        year=doc_info.get("year") or doc_info.get("period"),
+        retrieved_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
 # =============================================================================
 # COMPANY EXTRACTION AND RESOLUTION (Two-Stage Approach)
 # =============================================================================
@@ -547,17 +564,7 @@ def auto_load_relevant_documents(
                 document_texts[doc_name] = text
                 loaded_docs.append(doc_name)
                 # Only cite a document we actually read.
-                sources.append(
-                    Source(
-                        type=SourceType.DOCUMENT,
-                        title=doc_name,
-                        detail=doc_info.get("reason"),
-                        document_id=make_document_id(doc_link),
-                        company=doc_info.get("company"),
-                        year=doc_info.get("year") or doc_info.get("period"),
-                        retrieved_at=datetime.now(timezone.utc).isoformat(),
-                    )
-                )
+                sources.append(_build_document_source(doc_name, doc_link, doc_info))
                 record_document_load(source="s3", duration=load_duration, success=True)
             else:
                 record_document_load(source="error", duration=load_duration, success=False)
@@ -713,15 +720,7 @@ async def auto_load_relevant_documents_async(
                     successful_downloads += 1
                     # Only cite a document we actually read.
                     sources.append(
-                        Source(
-                            type=SourceType.DOCUMENT,
-                            title=doc_name,
-                            detail=doc_info.get("reason"),
-                            document_id=make_document_id(doc_info["document_link"]),
-                            company=doc_info.get("company"),
-                            year=doc_info.get("year") or doc_info.get("period"),
-                            retrieved_at=datetime.now(timezone.utc).isoformat(),
-                        )
+                        _build_document_source(doc_name, doc_info["document_link"], doc_info)
                     )
                     # Record successful async document load from S3
                     record_document_load(source="s3", duration=result.download_time, success=True)

--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -1002,9 +1002,7 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
 
             return []
 
-    def describe_source(
-        self, filters: FinancialDataFilters, record_count: int
-    ) -> Source:
+    def describe_source(self, filters: FinancialDataFilters, record_count: int) -> Source:
         """Describe the dataset read for this answer.
 
         Honest provenance for a financial figure is the table plus the filters

--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import time
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import google.generativeai as genai
@@ -17,7 +18,7 @@ from app.dspy_modules import (
 )
 from app.gemini_client import get_genai_client
 from app.logging_config import get_logger
-from app.models import FinancialDataFilters, FinancialDataRecord
+from app.models import FinancialDataFilters, FinancialDataRecord, Source, SourceType
 from app.tracing import traced_observation
 from app.utils.cost_tracking import CostResult, calculate_cost_from_response
 from app.utils.monitoring import record_ai_request, record_bigquery_query
@@ -1000,6 +1001,31 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
             record_bigquery_query(duration=duration, rows_returned=0, success=False)
 
             return []
+
+    def describe_source(
+        self, filters: FinancialDataFilters, record_count: int
+    ) -> Source:
+        """Describe the dataset read for this answer.
+
+        Honest provenance for a financial figure is the table plus the filters
+        applied. The table carries no reference to the statement PDF a figure
+        was extracted from, so this deliberately stops at the query rather than
+        implying a document-level citation it cannot support.
+        """
+        return Source(
+            type=SourceType.DATASET,
+            title="JSE financial statements dataset",
+            detail="Figures read directly from the JSE financial statements table",
+            table=f"{self.project_id}.{self.dataset}.{self.table}",
+            filters={
+                "companies": list(filters.companies or []),
+                "symbols": list(filters.symbols or []),
+                "years": list(filters.years or []),
+                "standard_items": list(filters.standard_items or []),
+            },
+            record_count=record_count,
+            retrieved_at=datetime.now(timezone.utc).isoformat(),
+        )
 
     def validate_data_availability(self, filters: FinancialDataFilters) -> Dict[str, Any]:
         logger.info(

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -474,6 +474,7 @@ async def chat(
         document_texts = {}
         document_selection_message = None
         loaded_docs = []
+        doc_sources = []
 
         # Auto-load relevant documents if enabled
         if request.auto_load_documents:
@@ -482,7 +483,7 @@ async def chat(
             if financial_manager and financial_manager.metadata:
                 associations = financial_manager.metadata.get("associations")
 
-            document_texts, document_selection_message, loaded_docs = auto_load_relevant_documents(
+            load_result = auto_load_relevant_documents(
                 s3_client,
                 request.query,
                 metadata,
@@ -490,6 +491,10 @@ async def chat(
                 request.conversation_history,
                 associations,
             )
+            document_texts = load_result.texts
+            document_selection_message = load_result.message
+            loaded_docs = load_result.loaded_docs
+            doc_sources = load_result.sources
 
         # Generate response
         response_text = generate_chat_response(
@@ -525,6 +530,7 @@ async def chat(
             documents_loaded=loaded_docs if loaded_docs else None,
             document_selection_message=document_selection_message,
             conversation_history=updated_conversation_history,
+            sources=doc_sources if doc_sources else None,
         )
 
     except Exception as e:

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1010,7 +1010,7 @@ async def chat_stream(
                     "warnings": response.warnings,
                     "suggestions": response.suggestions,
                     "chart": _jsonable(response.chart),
-                    "sources": response.sources,
+                    "sources": _jsonable(response.sources),
                     "web_search_results": response.web_search_results,
                     "tools_executed": response.tools_executed,
                     "needs_clarification": response.needs_clarification,

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -629,11 +629,7 @@ async def fast_chat_v2(
                 else None
             )
             chart_spec = ChartSpec(**cached["chart"]) if cached.get("chart") else None
-            sources = (
-                [Source(**s) for s in cached["sources"]]
-                if cached.get("sources")
-                else None
-            )
+            sources = [Source(**s) for s in cached["sources"]] if cached.get("sources") else None
 
             updated_conversation_history = None
             if request.memory_enabled:
@@ -721,9 +717,7 @@ async def fast_chat_v2(
                     )
 
             sources = (
-                [financial_manager.describe_source(filters, len(results))]
-                if results
-                else None
+                [financial_manager.describe_source(filters, len(results))] if results else None
             )
 
             if trace_obs is not None:

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -16,6 +16,9 @@ from app.models import (
     FinancialDataResponse,
     AgentChatRequest,
     AgentChatResponse,
+    Source,
+    FinancialDataFilters,
+    FinancialDataRecord,
 )
 from app.charting import generate_chart
 from app.document_registry import build_document_index, presign_document
@@ -626,6 +629,11 @@ async def fast_chat_v2(
                 else None
             )
             chart_spec = ChartSpec(**cached["chart"]) if cached.get("chart") else None
+            sources = (
+                [Source(**s) for s in cached["sources"]]
+                if cached.get("sources")
+                else None
+            )
 
             updated_conversation_history = None
             if request.memory_enabled:
@@ -652,6 +660,7 @@ async def fast_chat_v2(
                 warnings=cached.get("warnings"),
                 suggestions=cached.get("suggestions"),
                 chart=chart_spec,
+                sources=sources,
             )
 
         last_query_data = getattr(request, "_last_query_data", None)
@@ -711,6 +720,12 @@ async def fast_chat_v2(
                         f"Generated {chart_data['chart_type']} chart: {chart_data['title']}"
                     )
 
+            sources = (
+                [financial_manager.describe_source(filters, len(results))]
+                if results
+                else None
+            )
+
             if trace_obs is not None:
                 trace_obs.update(output=ai_response, metadata={"cache_hit": False})
 
@@ -730,6 +745,7 @@ async def fast_chat_v2(
                     "warnings": warnings if warnings else None,
                     "suggestions": suggestions if suggestions else None,
                     "chart": chart_spec.model_dump() if chart_spec else None,
+                    "sources": _jsonable(sources),
                 },
             )
 
@@ -755,6 +771,7 @@ async def fast_chat_v2(
             warnings=warnings if warnings else None,
             suggestions=suggestions if suggestions else None,
             chart=chart_spec,
+            sources=sources,
         )
     except HTTPException as e:
         schedule_log(response=None, cache_hit=False, success=False, error_message=str(e.detail))

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -826,7 +826,7 @@ async def resolve_document(
     """
     entry = document_index.get(document_id)
     if not entry:
-        logger.info(f"document_resolve_miss id={document_id[:32]}")
+        logger.warning(f"document_resolve_miss id={document_id[:32]}")
         raise HTTPException(status_code=404, detail="Document not found")
 
     try:

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse, JSONResponse, Response
+from fastapi.responses import StreamingResponse, JSONResponse, Response, RedirectResponse
 import time
 import uuid
 import asyncio
@@ -18,6 +18,7 @@ from app.models import (
     AgentChatResponse,
 )
 from app.charting import generate_chart
+from app.document_registry import build_document_index, presign_document
 from app.s3_client import init_s3_client
 from app.gemini_client import (
     init_vertex_ai,
@@ -77,6 +78,8 @@ async def lifespan(app: FastAPI):
                 detail=e.detail,
             )
             app.state.metadata = None
+        # Index documents for citation resolution (GET /documents/{id}).
+        app.state.document_index = build_document_index(app.state.metadata)
         # -----------------------
         # Initialize Financial Data Manager (BigQuery)
         # -----------------------
@@ -215,6 +218,11 @@ def get_s3_client():
 # Dependency to get metadata
 def get_metadata():
     return app.state.metadata
+
+
+# Dependency to get the document index
+def get_document_index():
+    return getattr(app.state, "document_index", {}) or {}
 
 
 # Dependency to get financial data manager
@@ -786,6 +794,34 @@ async def get_financial_metadata(
         raise HTTPException(
             status_code=500, detail=f"Error retrieving financial metadata: {str(e)}"
         )
+
+
+@app.get("/documents/{document_id}")
+async def resolve_document(
+    document_id: str,
+    s3_client: Any = Depends(get_s3_client),
+    document_index: Dict = Depends(get_document_index),
+):
+    """Resolve a cited document to a short-lived presigned S3 URL.
+
+    `document_id` is a one-way hash, so this is a lookup against the documents
+    present in metadata.json — an id we did not mint resolves to nothing.
+    """
+    entry = document_index.get(document_id)
+    if not entry:
+        logger.info(f"document_resolve_miss id={document_id[:32]}")
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    try:
+        url = presign_document(s3_client, entry["s3_path"])
+    except ValueError as e:
+        logger.error(f"document_resolve_bad_path id={document_id}: {e}")
+        raise HTTPException(status_code=404, detail="Document not found")
+    except Exception as e:
+        logger.error(f"document_resolve_failed id={document_id}: {e}")
+        raise HTTPException(status_code=500, detail="Could not resolve document")
+
+    return RedirectResponse(url=url, status_code=307)
 
 
 @app.get("/cache/status")

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -4,6 +4,53 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 
+class SourceType(str, Enum):
+    """Kind of evidence backing an answer."""
+
+    WEB = "web"  # Google Search grounding chunk
+    DOCUMENT = "document"  # PDF in S3
+    DATASET = "dataset"  # BigQuery financial table
+
+
+class Source(BaseModel):
+    """A single piece of provenance for an answer.
+
+    Only `type` and `title` are required — a client that understands nothing
+    else can still render a citation line. Per-type fields are optional so new
+    source kinds can be added without breaking existing consumers.
+    """
+
+    type: SourceType = Field(..., description="Kind of source backing the answer")
+    title: str = Field(..., description="Human-readable source name")
+    detail: Optional[str] = Field(default=None, description="Why this source was used")
+    retrieved_at: Optional[str] = Field(
+        default=None, description="ISO 8601 time the underlying retrieval ran"
+    )
+
+    # --- web ---
+    url: Optional[str] = Field(
+        default=None,
+        description="Source URL. Gemini grounding URIs expire (~30 days).",
+    )
+    domain: Optional[str] = Field(
+        default=None, description="Publisher domain. Outlives an expired url."
+    )
+
+    # --- document ---
+    document_id: Optional[str] = Field(
+        default=None, description="Opaque id. Resolve via GET /documents/{document_id}"
+    )
+    company: Optional[str] = Field(default=None, description="Company the document belongs to")
+    year: Optional[str] = Field(default=None, description="Reporting year of the document")
+
+    # --- dataset ---
+    table: Optional[str] = Field(default=None, description="Fully-qualified BigQuery table")
+    filters: Optional[Dict[str, Any]] = Field(
+        default=None, description="Filters applied when reading the table"
+    )
+    record_count: Optional[int] = Field(default=None, description="Rows matched by the query")
+
+
 class ChatRequest(BaseModel):
     """
     Request model for chat endpoint
@@ -62,6 +109,9 @@ class ChatResponse(BaseModel):
     )
     conversation_history: Optional[List[Dict[str, str]]] = Field(
         default=None, description="Updated conversation history"
+    )
+    sources: Optional[List[Source]] = Field(
+        default=None, description="Provenance for the answer (document sources)"
     )
 
 
@@ -151,6 +201,9 @@ class FinancialDataResponse(BaseModel):
     )
     chart: Optional[ChartSpec] = Field(
         default=None, description="Vega-Lite chart specification if data is chartable"
+    )
+    sources: Optional[List[Source]] = Field(
+        default=None, description="Provenance for the answer (dataset sources)"
     )
 
 
@@ -250,9 +303,8 @@ class AgentChatResponse(BaseModel):
     )
 
     # === NEW FIELDS (agent-specific, additive only) ===
-    sources: Optional[List[Dict[str, Any]]] = Field(
-        default=None,
-        description="List of sources cited in the response (values may be strings or lists)",
+    sources: Optional[List[Source]] = Field(
+        default=None, description="Provenance for the answer (web sources)"
     )
     web_search_results: Optional[Dict[str, Any]] = Field(
         default=None, description="Google Search grounding metadata"

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -21,8 +21,17 @@ class Source(BaseModel):
     """
 
     type: SourceType = Field(..., description="Kind of source backing the answer")
-    title: str = Field(..., description="Human-readable source name")
-    detail: Optional[str] = Field(default=None, description="Why this source was used")
+    title: str = Field(
+        ...,
+        description=(
+            "Human-readable source name. For web sources this is third-party-supplied "
+            "and must be escaped before rendering."
+        ),
+    )
+    detail: Optional[str] = Field(
+        default=None,
+        description="Why this source was used. Model-generated text; must be escaped before rendering.",
+    )
     retrieved_at: Optional[str] = Field(
         default=None, description="ISO 8601 time the underlying retrieval ran"
     )
@@ -30,10 +39,17 @@ class Source(BaseModel):
     # --- web ---
     url: Optional[str] = Field(
         default=None,
-        description="Source URL. Gemini grounding URIs expire (~30 days).",
+        description=(
+            "Source URL. Gemini grounding URIs expire (~30 days). Third-party-supplied — "
+            "consumers must allowlist the scheme to https: before using it in an href."
+        ),
     )
     domain: Optional[str] = Field(
-        default=None, description="Publisher domain. Outlives an expired url."
+        default=None,
+        description=(
+            "Publisher domain. Outlives an expired url. Third-party-supplied; "
+            "must be escaped before rendering."
+        ),
     )
 
     # --- document ---

--- a/fastapi_app/app/response_cache.py
+++ b/fastapi_app/app/response_cache.py
@@ -53,7 +53,12 @@ class ResponseCache:
         """
         normalized = "|".join(str(p) for p in parts)
         digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-        return f"cache:v1:{namespace}:{digest}"
+        # Bump this version prefix whenever a cached payload's schema changes
+        # (e.g. a new required field on a response model). That makes every
+        # entry written under the old schema unreadable by construction,
+        # instead of risking a deserialization error against live traffic
+        # for the remainder of the cache TTL.
+        return f"cache:v2:{namespace}:{digest}"
 
     @staticmethod
     def normalize_query(query: str) -> str:

--- a/fastapi_app/test_async_integration.py
+++ b/fastapi_app/test_async_integration.py
@@ -146,12 +146,15 @@ async def test_concurrent_downloads():
         ]
 
         # Test concurrent loading
-        document_texts, message, loaded_docs = await auto_load_relevant_documents_async(
+        result = await auto_load_relevant_documents_async(
             query="Tell me about TestCorp financials",
             metadata=MOCK_METADATA,
             config=config,
             progress_callback=progress_callback,
         )
+        document_texts = result.texts
+        message = result.message
+        loaded_docs = result.loaded_docs
 
         # Verify results
         assert len(document_texts) == 3, f"Expected 3 documents, got {len(document_texts)}"

--- a/fastapi_app/tests/test_async_s3_downloads.py
+++ b/fastapi_app/tests/test_async_s3_downloads.py
@@ -404,12 +404,15 @@ class TestConcurrentDocumentLoading:
             DownloadResult(success=True, content="Content 2", download_time=1.5),
         ]
 
-        document_texts, message, loaded_docs = await auto_load_relevant_documents_async(
+        result = await auto_load_relevant_documents_async(
             query="Tell me about TestCorp",
             metadata=mock_metadata,
             config=download_config,
             progress_callback=mock_progress_callback,
         )
+        document_texts = result.texts
+        message = result.message
+        loaded_docs = result.loaded_docs
 
         assert len(document_texts) == 2
         assert "test1.pdf" in document_texts
@@ -452,12 +455,15 @@ class TestConcurrentDocumentLoading:
             DownloadResult(success=False, error="Download failed", download_time=2.0),
         ]
 
-        document_texts, message, loaded_docs = await auto_load_relevant_documents_async(
+        result = await auto_load_relevant_documents_async(
             query="Tell me about TestCorp",
             metadata=mock_metadata,
             config=download_config,
             progress_callback=mock_progress_callback,
         )
+        document_texts = result.texts
+        message = result.message
+        loaded_docs = result.loaded_docs
 
         assert len(document_texts) == 1
         assert "test1.pdf" in document_texts

--- a/fastapi_app/tests/test_documents_endpoint.py
+++ b/fastapi_app/tests/test_documents_endpoint.py
@@ -1,0 +1,71 @@
+"""Tests for GET /documents/{document_id}.
+
+The resolver is the only path from a citation to the underlying PDF. It must
+resolve exactly the documents present in metadata.json and nothing else — an
+unknown or tampered id gets a 404, never a presigned URL.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.document_registry import build_document_index, make_document_id
+from app.main import app
+
+S3_PATH = "s3://jse-renamed-docs-copy-2/organized/ncb/annual_2023.pdf"
+METADATA = {
+    "NCB Financial Group": [
+        {
+            "filename": "ncb_annual_report_2023.pdf",
+            "document_link": S3_PATH,
+            "year": "2023",
+        }
+    ]
+}
+
+
+@pytest.fixture
+def client():
+    app.state.metadata = METADATA
+    app.state.document_index = build_document_index(METADATA)
+    mock_s3 = MagicMock()
+    mock_s3.generate_presigned_url.return_value = "https://s3.example/presigned?sig=abc"
+    app.state.s3_client = mock_s3
+    test_client = TestClient(app)
+    yield test_client
+
+
+@pytest.mark.integration
+class TestDocumentResolver:
+    def test_known_id_redirects_to_presigned_url(self, client):
+        doc_id = make_document_id(S3_PATH)
+        response = client.get(f"/documents/{doc_id}", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "https://s3.example/presigned?sig=abc"
+
+    def test_presigned_url_is_short_lived(self, client):
+        doc_id = make_document_id(S3_PATH)
+        client.get(f"/documents/{doc_id}", follow_redirects=False)
+        _, kwargs = app.state.s3_client.generate_presigned_url.call_args
+        assert kwargs["ExpiresIn"] == 300
+        assert kwargs["Params"]["Bucket"] == "jse-renamed-docs-copy-2"
+        assert kwargs["Params"]["Key"] == "organized/ncb/annual_2023.pdf"
+
+    def test_unknown_id_returns_404(self, client):
+        response = client.get("/documents/0000000000000000", follow_redirects=False)
+        assert response.status_code == 404
+        app.state.s3_client.generate_presigned_url.assert_not_called()
+
+    def test_tampered_id_returns_404(self, client):
+        """Flipping one character must not resolve to anything."""
+        doc_id = make_document_id(S3_PATH)
+        tampered = ("0" if doc_id[0] != "0" else "1") + doc_id[1:]
+        response = client.get(f"/documents/{tampered}", follow_redirects=False)
+        assert response.status_code == 404
+        app.state.s3_client.generate_presigned_url.assert_not_called()
+
+    def test_path_traversal_attempt_does_not_resolve(self, client):
+        response = client.get("/documents/..%2F..%2Fetc%2Fpasswd", follow_redirects=False)
+        assert response.status_code == 404
+        app.state.s3_client.generate_presigned_url.assert_not_called()

--- a/fastapi_app/tests/test_documents_endpoint.py
+++ b/fastapi_app/tests/test_documents_endpoint.py
@@ -26,14 +26,13 @@ METADATA = {
 
 
 @pytest.fixture
-def client():
-    app.state.metadata = METADATA
-    app.state.document_index = build_document_index(METADATA)
+def client(monkeypatch):
+    monkeypatch.setattr(app.state, "metadata", METADATA, raising=False)
+    monkeypatch.setattr(app.state, "document_index", build_document_index(METADATA), raising=False)
     mock_s3 = MagicMock()
     mock_s3.generate_presigned_url.return_value = "https://s3.example/presigned?sig=abc"
-    app.state.s3_client = mock_s3
-    test_client = TestClient(app)
-    yield test_client
+    monkeypatch.setattr(app.state, "s3_client", mock_s3, raising=False)
+    yield TestClient(app)
 
 
 @pytest.mark.integration

--- a/fastapi_app/tests/unit/test_agent_v2_sources.py
+++ b/fastapi_app/tests/unit/test_agent_v2_sources.py
@@ -1,0 +1,109 @@
+"""Unit tests for web source extraction from Gemini grounding metadata.
+
+Gemini returns one grounding chunk per grounding support, so the same URL
+appears several times in a single response — the extracted source list must
+be deduped. Grounding URIs are vertexaisearch redirects that expire after
+about 30 days, so `domain` is captured separately: when the link dies, the
+citation degrades to readable text instead of to nothing.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.agent_v2 import AgentV2
+from app.models import SourceType
+
+
+def _web_chunk(uri, title, domain=None):
+    """Build a grounding chunk.
+
+    `spec` is required: a bare MagicMock auto-creates any attribute, so
+    `getattr(web, "domain", None)` would return a Mock instead of None and the
+    fallback path would never be exercised.
+    """
+    spec = ["uri", "title"] + (["domain"] if domain is not None else [])
+    web = MagicMock(spec=spec)
+    web.uri = uri
+    web.title = title
+    if domain is not None:
+        web.domain = domain
+    chunk = MagicMock(spec=["web"])
+    chunk.web = web
+    return chunk
+
+
+def _grounded_response(chunks):
+    grounding = MagicMock(spec=["grounding_chunks", "web_search_queries", "search_entry_point"])
+    grounding.grounding_chunks = chunks
+    grounding.web_search_queries = ["ncb net profit 2023"]
+    entry_point = MagicMock(spec=["rendered_content"])
+    entry_point.rendered_content = "<div></div>"
+    grounding.search_entry_point = entry_point
+    candidate = MagicMock(spec=["grounding_metadata"])
+    candidate.grounding_metadata = grounding
+    response = MagicMock(spec=["candidates"])
+    response.candidates = [candidate]
+    return response
+
+
+@pytest.fixture
+def agent():
+    with patch("app.agent_v2.get_genai_client"):
+        yield AgentV2()
+
+
+@pytest.mark.unit
+class TestWebSourceExtraction:
+    def test_duplicate_urls_are_deduped(self, agent):
+        response = _grounded_response(
+            [
+                _web_chunk("https://jse.com/a", "jamstockex.com"),
+                _web_chunk("https://jse.com/a", "jamstockex.com"),
+                _web_chunk("https://jse.com/b", "jamstockex.com"),
+            ]
+        )
+        sources = agent._extract_grounding_metadata(response)["sources"]
+        assert len(sources) == 2
+        assert [s.url for s in sources] == ["https://jse.com/a", "https://jse.com/b"]
+
+    def test_sources_are_typed_web(self, agent):
+        response = _grounded_response([_web_chunk("https://jse.com/a", "jamstockex.com")])
+        source = agent._extract_grounding_metadata(response)["sources"][0]
+        assert source.type == SourceType.WEB
+        assert source.title == "jamstockex.com"
+
+    def test_domain_field_is_preferred_when_present(self, agent):
+        response = _grounded_response(
+            [_web_chunk("https://x/a", "JSE Annual Review", domain="jamstockex.com")]
+        )
+        source = agent._extract_grounding_metadata(response)["sources"][0]
+        assert source.domain == "jamstockex.com"
+        assert source.title == "JSE Annual Review"
+
+    def test_domain_falls_back_to_title(self, agent):
+        response = _grounded_response([_web_chunk("https://x/a", "jamstockex.com")])
+        source = agent._extract_grounding_metadata(response)["sources"][0]
+        assert source.domain == "jamstockex.com"
+
+    def test_retrieved_at_is_populated(self, agent):
+        response = _grounded_response([_web_chunk("https://x/a", "jamstockex.com")])
+        source = agent._extract_grounding_metadata(response)["sources"][0]
+        assert source.retrieved_at is not None
+        assert "T" in source.retrieved_at  # ISO 8601
+
+    def test_chunks_without_uri_are_skipped(self, agent):
+        response = _grounded_response([_web_chunk("", "jamstockex.com")])
+        assert agent._extract_grounding_metadata(response)["sources"] == []
+
+    def test_no_candidates_yields_no_sources(self, agent):
+        response = MagicMock(spec=["candidates"])
+        response.candidates = []
+        assert agent._extract_grounding_metadata(response)["sources"] == []
+
+    def test_search_results_still_populated(self, agent):
+        """web_search_results is a separate field and must not change shape."""
+        response = _grounded_response([_web_chunk("https://x/a", "jamstockex.com")])
+        results = agent._extract_grounding_metadata(response)["search_results"]
+        assert results["queries"] == ["ncb net profit 2023"]
+        assert results["grounding_chunks"] == [{"title": "jamstockex.com", "uri": "https://x/a"}]

--- a/fastapi_app/tests/unit/test_dataset_source.py
+++ b/fastapi_app/tests/unit/test_dataset_source.py
@@ -1,0 +1,88 @@
+"""Unit tests for dataset provenance on /fast_chat_v2.
+
+A financial figure's honest provenance is the table it came from plus the
+filters applied — not a fabricated per-number URL. See the known limitation
+in the design doc: the table has no column pointing back to the statement
+PDF, so a dataset source deliberately stops at the query.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.financial_utils import FinancialDataManager
+from app.models import FinancialDataFilters, SourceType
+
+
+@pytest.fixture
+def manager():
+    with patch.object(FinancialDataManager, "__init__", lambda self: None):
+        mgr = FinancialDataManager()
+    mgr.project_id = "jse-proj"
+    mgr.dataset = "financials"
+    mgr.table = "statements"
+    return mgr
+
+
+@pytest.mark.unit
+class TestDescribeSource:
+    def test_source_is_typed_dataset(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 0)
+        assert source.type == SourceType.DATASET
+
+    def test_table_is_fully_qualified(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 3)
+        assert source.table == "jse-proj.financials.statements"
+
+    def test_record_count_is_carried(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 42)
+        assert source.record_count == 42
+
+    def test_only_query_shaping_filters_are_included(self, manager):
+        """Conversational fields describe interpretation, not what was read."""
+        filters = FinancialDataFilters(
+            companies=["NCB Financial Group"],
+            symbols=["NCBFG"],
+            years=["2023"],
+            standard_items=["net_profit"],
+            interpretation="user wants NCB net profit",
+            is_follow_up=True,
+            context_used="previous turn",
+            data_availability_note="note",
+            unrecognized_items=["ebitda"],
+        )
+        source = manager.describe_source(filters, 4)
+        assert source.filters == {
+            "companies": ["NCB Financial Group"],
+            "symbols": ["NCBFG"],
+            "years": ["2023"],
+            "standard_items": ["net_profit"],
+        }
+
+    def test_title_names_the_dataset_readably(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 1)
+        assert source.title
+        assert "jse-proj" not in source.title  # a title, not a table id
+
+    def test_retrieved_at_is_populated(self, manager):
+        source = manager.describe_source(FinancialDataFilters(), 1)
+        assert source.retrieved_at is not None
+
+
+@pytest.mark.unit
+class TestSourceCacheRoundTrip:
+    def test_source_survives_json_round_trip(self, manager):
+        """Sources go through Redis as JSON; nothing in them may be unserializable."""
+        import json
+
+        from app.main import _jsonable
+        from app.models import Source
+
+        source = manager.describe_source(
+            FinancialDataFilters(companies=["NCB"], years=["2023"]), 5
+        )
+        payload = json.loads(json.dumps(_jsonable([source])))
+        restored = [Source(**item) for item in payload]
+        assert restored[0].table == source.table
+        assert restored[0].filters == source.filters
+        assert restored[0].record_count == 5

--- a/fastapi_app/tests/unit/test_dataset_source.py
+++ b/fastapi_app/tests/unit/test_dataset_source.py
@@ -78,9 +78,7 @@ class TestSourceCacheRoundTrip:
         from app.main import _jsonable
         from app.models import Source
 
-        source = manager.describe_source(
-            FinancialDataFilters(companies=["NCB"], years=["2023"]), 5
-        )
+        source = manager.describe_source(FinancialDataFilters(companies=["NCB"], years=["2023"]), 5)
         payload = json.loads(json.dumps(_jsonable([source])))
         restored = [Source(**item) for item in payload]
         assert restored[0].table == source.table

--- a/fastapi_app/tests/unit/test_document_registry.py
+++ b/fastapi_app/tests/unit/test_document_registry.py
@@ -2,8 +2,10 @@
 
 `document_id` is deliberately a one-way hash rather than an encoded S3 path.
 If it were reversible (e.g. base64), a client could edit the id and read
-arbitrary objects out of the bucket through our own resolver endpoint.
-Because resolution is a dict lookup built from metadata.json, no crafted
+arbitrary objects out of the bucket through our own resolver endpoint. The
+hash is unsalted, so it is not a secret — anyone who guesses the S3 path can
+compute the same id offline — but it is non-reversible and index-bounded:
+because resolution is a dict lookup built from metadata.json, no crafted
 input can reach an object we did not index.
 """
 

--- a/fastapi_app/tests/unit/test_document_registry.py
+++ b/fastapi_app/tests/unit/test_document_registry.py
@@ -1,0 +1,107 @@
+"""Unit tests for the document registry.
+
+`document_id` is deliberately a one-way hash rather than an encoded S3 path.
+If it were reversible (e.g. base64), a client could edit the id and read
+arbitrary objects out of the bucket through our own resolver endpoint.
+Because resolution is a dict lookup built from metadata.json, no crafted
+input can reach an object we did not index.
+"""
+
+import pytest
+
+from app.document_registry import (
+    build_document_index,
+    make_document_id,
+    parse_s3_path,
+)
+
+METADATA = {
+    "NCB Financial Group": [
+        {
+            "filename": "ncb_annual_report_2023.pdf",
+            "document_link": "s3://jse-renamed-docs-copy-2/organized/ncb/annual_2023.pdf",
+            "year": "2023",
+        },
+        {
+            "filename": "ncb_q4_2023.pdf",
+            "document_link": "s3://jse-renamed-docs-copy-2/organized/ncb/q4_2023.pdf",
+            "period": "2023",
+        },
+    ],
+    "GraceKennedy": [
+        {
+            "filename": "gk_annual_report_2024.pdf",
+            "document_link": "s3://jse-renamed-docs-copy-2/organized/gk/annual_2024.pdf",
+            "year": "2024",
+        }
+    ],
+}
+
+
+@pytest.mark.unit
+class TestMakeDocumentId:
+    def test_is_stable(self):
+        path = "s3://bucket/key.pdf"
+        assert make_document_id(path) == make_document_id(path)
+
+    def test_is_sixteen_hex_chars(self):
+        doc_id = make_document_id("s3://bucket/key.pdf")
+        assert len(doc_id) == 16
+        assert all(c in "0123456789abcdef" for c in doc_id)
+
+    def test_differs_per_path(self):
+        assert make_document_id("s3://bucket/a.pdf") != make_document_id("s3://bucket/b.pdf")
+
+    def test_leaks_no_path_material(self):
+        """The id must not reveal bucket or key — it is a lookup key, not a codec."""
+        doc_id = make_document_id("s3://secret-bucket/organized/private.pdf")
+        assert "secret-bucket" not in doc_id
+        assert "private" not in doc_id
+        assert "organized" not in doc_id
+
+
+@pytest.mark.unit
+class TestBuildDocumentIndex:
+    def test_indexes_every_document(self):
+        index = build_document_index(METADATA)
+        assert len(index) == 3
+
+    def test_entry_carries_resolution_fields(self):
+        index = build_document_index(METADATA)
+        doc_id = make_document_id("s3://jse-renamed-docs-copy-2/organized/gk/annual_2024.pdf")
+        entry = index[doc_id]
+        assert entry["s3_path"] == "s3://jse-renamed-docs-copy-2/organized/gk/annual_2024.pdf"
+        assert entry["filename"] == "gk_annual_report_2024.pdf"
+        assert entry["company"] == "GraceKennedy"
+        assert entry["year"] == "2024"
+
+    def test_period_is_used_when_year_is_absent(self):
+        index = build_document_index(METADATA)
+        doc_id = make_document_id("s3://jse-renamed-docs-copy-2/organized/ncb/q4_2023.pdf")
+        assert index[doc_id]["year"] == "2023"
+
+    def test_documents_without_a_link_are_skipped(self):
+        index = build_document_index({"ACME": [{"filename": "no_link.pdf"}]})
+        assert index == {}
+
+    def test_none_metadata_yields_empty_index(self):
+        assert build_document_index(None) == {}
+
+    def test_malformed_metadata_is_tolerated(self):
+        """Metadata comes from S3 — a bad shape must not crash startup."""
+        assert build_document_index({"ACME": "not-a-list"}) == {}
+        assert build_document_index({"ACME": ["not-a-dict"]}) == {}
+
+
+@pytest.mark.unit
+class TestParseS3Path:
+    def test_splits_bucket_and_key(self):
+        assert parse_s3_path("s3://my-bucket/a/b/c.pdf") == ("my-bucket", "a/b/c.pdf")
+
+    def test_rejects_non_s3_scheme(self):
+        with pytest.raises(ValueError):
+            parse_s3_path("https://my-bucket/a.pdf")
+
+    def test_rejects_bucket_without_key(self):
+        with pytest.raises(ValueError):
+            parse_s3_path("s3://my-bucket")

--- a/fastapi_app/tests/unit/test_document_selector.py
+++ b/fastapi_app/tests/unit/test_document_selector.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from app.document_selector import (
+    DocumentLoadResult,
     auto_load_relevant_documents,
     auto_load_relevant_documents_async,
     resolve_companies,
@@ -50,8 +51,10 @@ class TestDocumentSelector:
                 query="MTN report",
                 metadata=mock_metadata,
             )
-            assert isinstance(result, tuple)
-            assert len(result) == 3  # (document_texts, message, loaded_docs)
+            assert isinstance(result, DocumentLoadResult)
+            assert isinstance(result.texts, dict)
+            assert isinstance(result.loaded_docs, list)
+            assert isinstance(result.sources, list)
 
     def test_auto_load_relevant_documents(self, mock_metadata, mock_s3_client):
         """Test synchronous document loading."""
@@ -61,8 +64,10 @@ class TestDocumentSelector:
             metadata=mock_metadata,
             current_document_texts={},
         )
-        assert isinstance(result, tuple)
-        assert len(result) == 3  # (document_texts, message, loaded_docs)
+        assert isinstance(result, DocumentLoadResult)
+        assert isinstance(result.texts, dict)
+        assert isinstance(result.loaded_docs, list)
+        assert isinstance(result.sources, list)
 
     def test_semantic_selection_with_conversation_history(self, mock_metadata):
         """Test semantic selection with conversation history."""

--- a/fastapi_app/tests/unit/test_document_sources.py
+++ b/fastapi_app/tests/unit/test_document_sources.py
@@ -1,0 +1,94 @@
+"""Unit tests for document provenance returned by the /chat loader.
+
+The loader has always had document_link and the selection reason in scope
+and thrown them away, returning bare filenames. Users fact-checking an
+answer need to reach the actual PDF, so the loader now returns Source
+objects carrying an opaque document_id the resolver endpoint can redeem.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.document_registry import make_document_id
+from app.document_selector import DocumentLoadResult, auto_load_relevant_documents
+from app.models import SourceType
+
+S3_PATH = "s3://jse-renamed-docs-copy-2/organized/ncb/annual_2023.pdf"
+
+RECOMMENDATION = {
+    "companies_mentioned": ["NCB Financial Group"],
+    "documents_to_load": [
+        {
+            "company": "NCB Financial Group",
+            "document_link": S3_PATH,
+            "filename": "ncb_annual_report_2023.pdf",
+            "reason": "Contains FY2023 net profit",
+        }
+    ],
+}
+
+
+@pytest.fixture
+def loaded():
+    with (
+        patch("app.document_selector.semantic_document_selection") as mock_select,
+        patch("app.document_selector.download_and_extract_from_s3") as mock_download,
+    ):
+        mock_select.return_value = RECOMMENDATION
+        mock_download.return_value = "extracted pdf text"
+        yield auto_load_relevant_documents(
+            s3_client=Mock(),
+            query="NCB net profit 2023",
+            metadata={"NCB Financial Group": []},
+            current_document_texts={},
+        )
+
+
+@pytest.mark.unit
+class TestDocumentSources:
+    def test_returns_a_document_load_result(self, loaded):
+        assert isinstance(loaded, DocumentLoadResult)
+
+    def test_loaded_docs_still_lists_filenames(self, loaded):
+        """Backward compatibility: ChatResponse.documents_loaded is unchanged."""
+        assert loaded.loaded_docs == ["ncb_annual_report_2023.pdf"]
+
+    def test_texts_are_keyed_by_filename(self, loaded):
+        assert loaded.texts["ncb_annual_report_2023.pdf"] == "extracted pdf text"
+
+    def test_source_is_typed_document(self, loaded):
+        assert loaded.sources[0].type == SourceType.DOCUMENT
+
+    def test_source_carries_resolvable_document_id(self, loaded):
+        assert loaded.sources[0].document_id == make_document_id(S3_PATH)
+
+    def test_source_never_exposes_the_s3_path(self, loaded):
+        """The bucket layout must not reach the browser."""
+        dumped = loaded.sources[0].model_dump()
+        assert S3_PATH not in str(dumped)
+        assert "jse-renamed-docs-copy-2" not in str(dumped)
+
+    def test_source_carries_selection_reason_and_company(self, loaded):
+        source = loaded.sources[0]
+        assert source.title == "ncb_annual_report_2023.pdf"
+        assert source.detail == "Contains FY2023 net profit"
+        assert source.company == "NCB Financial Group"
+        assert source.retrieved_at is not None
+
+    def test_failed_download_produces_no_source(self):
+        """A document we could not read must not be cited as evidence."""
+        with (
+            patch("app.document_selector.semantic_document_selection") as mock_select,
+            patch("app.document_selector.download_and_extract_from_s3") as mock_download,
+        ):
+            mock_select.return_value = RECOMMENDATION
+            mock_download.return_value = None
+            result = auto_load_relevant_documents(
+                s3_client=Mock(),
+                query="NCB net profit 2023",
+                metadata={"NCB Financial Group": []},
+                current_document_texts={},
+            )
+        assert result.loaded_docs == []
+        assert result.sources == []

--- a/fastapi_app/tests/unit/test_document_sources.py
+++ b/fastapi_app/tests/unit/test_document_sources.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from app.document_registry import make_document_id
+from app.document_registry import build_document_index, make_document_id
 from app.document_selector import DocumentLoadResult, auto_load_relevant_documents
 from app.models import SourceType
 
@@ -24,6 +24,19 @@ RECOMMENDATION = {
             "document_link": S3_PATH,
             "filename": "ncb_annual_report_2023.pdf",
             "reason": "Contains FY2023 net profit",
+        }
+    ],
+}
+
+# Mirrors what actually lives in metadata.json for this document, so the
+# round-trip test below exercises the same shape build_document_index sees
+# in production (not just the recommendation payload the mocked LLM echoes).
+METADATA = {
+    "NCB Financial Group": [
+        {
+            "filename": "ncb_annual_report_2023.pdf",
+            "document_link": S3_PATH,
+            "year": "2023",
         }
     ],
 }
@@ -75,6 +88,17 @@ class TestDocumentSources:
         assert source.detail == "Contains FY2023 net profit"
         assert source.company == "NCB Financial Group"
         assert source.retrieved_at is not None
+
+    def test_minted_document_id_is_resolvable(self, loaded):
+        """Round-trip check: the id _build_document_source mints from the
+        selection LLM's echoed document_link must match the id
+        build_document_index derives from the same path in metadata.json.
+        Two independent hash call sites must agree byte-for-byte, or a
+        citation's document_id 404s forever against the real resolver.
+        """
+        source_ids = {s.document_id for s in loaded.sources}
+        index = build_document_index(METADATA)
+        assert source_ids <= set(index)
 
     def test_failed_download_produces_no_source(self):
         """A document we could not read must not be cited as evidence."""

--- a/fastapi_app/tests/unit/test_source_model.py
+++ b/fastapi_app/tests/unit/test_source_model.py
@@ -1,0 +1,75 @@
+"""Unit tests for the Source provenance model.
+
+Every chat endpoint returns a `sources` array so users can fact-check an
+answer. Only `type` and `title` are required, so a client that understands
+nothing else can still render a meaningful citation line.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import (
+    AgentChatResponse,
+    ChatResponse,
+    FinancialDataFilters,
+    FinancialDataResponse,
+    Source,
+    SourceType,
+)
+
+
+@pytest.mark.unit
+class TestSourceModel:
+    def test_web_source_keeps_legacy_shape(self):
+        """Existing clients read type/title/url. Those must serialize verbatim."""
+        source = Source(
+            type=SourceType.WEB,
+            title="Jamaica Stock Exchange",
+            url="https://vertexaisearch.example/redirect/abc",
+        )
+        dumped = source.model_dump()
+        assert dumped["type"] == "web"
+        assert dumped["title"] == "Jamaica Stock Exchange"
+        assert dumped["url"] == "https://vertexaisearch.example/redirect/abc"
+
+    def test_type_and_title_are_sufficient(self):
+        source = Source(type=SourceType.DATASET, title="JSE financial statements")
+        assert source.url is None
+        assert source.document_id is None
+        assert source.record_count is None
+
+    def test_title_is_required(self):
+        with pytest.raises(ValidationError):
+            Source(type=SourceType.WEB)
+
+    def test_agent_response_coerces_source_dicts(self):
+        """Redis returns plain dicts; the response model must coerce them."""
+        built = AgentChatResponse(
+            response="r",
+            data_found=True,
+            record_count=0,
+            sources=[{"type": "web", "title": "T", "url": "https://x"}],
+        )
+        assert built.sources[0].type == SourceType.WEB
+        assert built.sources[0].title == "T"
+
+    def test_financial_response_accepts_sources(self):
+        built = FinancialDataResponse(
+            response="r",
+            data_found=True,
+            record_count=2,
+            filters_used=FinancialDataFilters(),
+            sources=[{"type": "dataset", "title": "JSE financials", "record_count": 2}],
+        )
+        assert built.sources[0].type == SourceType.DATASET
+        assert built.sources[0].record_count == 2
+
+    def test_chat_response_accepts_sources_alongside_documents_loaded(self):
+        """documents_loaded is retained for backward compatibility."""
+        built = ChatResponse(
+            response="r",
+            documents_loaded=["ncb_annual_2023.pdf"],
+            sources=[{"type": "document", "title": "ncb_annual_2023.pdf", "document_id": "abc123"}],
+        )
+        assert built.documents_loaded == ["ncb_annual_2023.pdf"]
+        assert built.sources[0].document_id == "abc123"

--- a/mock_client/chat_assistant_test_client.html
+++ b/mock_client/chat_assistant_test_client.html
@@ -941,7 +941,14 @@
         extraDetails.push(`Tools used: ${data.tools_executed.join(', ')}`);
       }
       if (data.sources?.length) {
-        const sourcesList = data.sources.map(s => s.description || s.type).join(', ');
+        const baseUrl = ENV_URLS[state.environment];
+        const sourcesList = data.sources.map(s => {
+          const label = s.title || s.domain || s.table || 'source';
+          if (s.type === 'web' && s.url) return `<a href="${s.url}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+          if (s.type === 'document' && s.document_id) return `<a href="${baseUrl}/documents/${s.document_id}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+          if (s.type === 'dataset') return `${label}${s.record_count != null ? ` (${s.record_count} rows)` : ''}`;
+          return label;
+        }).join(', ');
         extraDetails.push(`Sources: ${sourcesList}`);
       }
       if (data.suggestions?.length) {


### PR DESCRIPTION
Every chat endpoint now returns a typed `sources` array so users can fact-check answers and the UI can render a citations panel.

Before this, only `/chat/stream` returned sources — untyped `List[Dict[str, Any]]`, with duplicates — and `/fast_chat_v2` and `/chat` returned none at all.

## What's in it

A single polymorphic `Source` model with a `type` discriminator (`web` / `document` / `dataset`). Only `type` and `title` are required, so a client that understands nothing else can still render a citation line, and new source kinds stay additive.

| Endpoint | Source type | Carries |
|---|---|---|
| `/chat/stream` | `web` | `title`, `url`, `domain` — deduped by URL |
| `/fast_chat_v2` | `dataset` | fully-qualified `table`, four-key `filters`, `record_count` |
| `/chat` | `document` | opaque `document_id`, `company`, `year` |

New `GET /documents/{document_id}` redeems a document id for a 307 redirect to a 300s presigned S3 URL; unknown id returns 404.

**Backward compatible.** Web sources still serialize `{type, title, url}` verbatim, and `documents_loaded` is retained on `ChatResponse`.

## Two design choices worth knowing

**`domain` is not redundant with `url`.** Gemini grounding URIs are `vertexaisearch` redirects that expire in roughly 30 days. When the link dies, `domain` + `title` still tells a user who said it, so the citation degrades to text rather than to nothing.

**`document_id` is a lookup key, not an encoding.** It is `sha256(s3_path)[:16]`, resolved only against `metadata.json`, so no crafted input reaches an object we did not index. The hash is unsalted and is not a secret — the property that holds is non-reversible and index-bounded, not unguessable.

## Two pre-existing bugs fixed along the way

**`/fast_chat_v2`'s response cache has never worked.** Its cache-hit branch called `FinancialDataFilters(...)` and `FinancialDataRecord(...)` while `main.py` imported neither. Every cache hit raised `NameError`, was swallowed by the endpoint's broad `except Exception`, and returned a 500 — invisible because it only triggers on a repeat query and fails as a generic 500 rather than an import-time crash.

**Legacy cached entries would have 500'd `/chat/stream` after deploy.** Web sources cached by the old code can carry `"title": null`, which the now-required `Source.title` rejects. The response-cache key namespace is bumped to `v2` so legacy entries are unreadable by construction.

## Known limitation

The BigQuery table has no column referencing the PDF a figure was extracted from, so a dataset source cites the table and filters but cannot link to a statement page — the strongest form of fact-checking for financial figures. Closing that needs a source-document reference added upstream in the extraction pipeline. Recorded in the design doc rather than papered over.

## For the UI

Web source `title`, `domain`, and `url` come from third-party pages via Gemini grounding, and `detail` is model-generated. **Escape all source strings, and allowlist `url` to `https:` before using it in an `href`** — a `javascript:` URI arriving in a grounding chunk would otherwise be clickable script execution. Documented in the field descriptions and in `docs/CHATBOT_INTEGRATION_SPEC.md`, which also gained the real per-type schema and the resolver endpoint (it previously documented a `relevance` field the API has never emitted).

## Verification

- Suite: **36 failed / 193 passed / 14 errors** vs. a branch-point baseline of 36 failed / 145 passed / 14 errors. Failure and error counts identical — **zero regressions**. The 48 added tests account for the rise. (Note: `pytest tests` aborts at collection; use `--ignore=tests/archive`.)
- `ruff` and `black` clean. OpenAPI builds with `Source.required == ['type','title']` and the resolver route registered.
- Live smoke against real Gemini/BigQuery/S3: no duplicate URLs; exactly four filter keys; no `s3://`, bucket name, or key prefix anywhere in a `/chat` response body; 307 with a real presigned URL; 404 on unknown and tampered ids. Test client rendering verified in a browser DOM.

**Not verified:** the Redis cache round-trip. `REDIS_URL` is empty locally, so the cache is inert and the test would prove nothing. The JSON round-trip is covered by unit test; the live cache-hit path is not. Worth one check on dev — send the same `/fast_chat_v2` query twice with no conversation history and confirm the second returns 200 with `sources`.

## Reviewer's note

`GET /documents/{document_id}` ships **unauthenticated**, matching every other endpoint in `main.py`. That is safe today because every indexed document is already retrievable through the unauthenticated `/chat`. It stops being safe if a non-public document enters that bucket and `metadata.json`, at which point it becomes anonymously downloadable by anyone who can guess its key. If that is a possibility, say so and we will switch to an HMAC over the path with a server-side secret.

Design: `docs/superpowers/specs/2026-08-17-response-sources-provenance-design.md`
Plan: `docs/superpowers/plans/2026-08-17-response-sources-provenance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)