### PR TITLE
feat: log answer provenance to BigQuery, and cite rows read rather than parser filters

### DIFF
--- a/fastapi_app/app/financial_utils.py
+++ b/fastapi_app/app/financial_utils.py
@@ -1002,26 +1002,45 @@ Return ONLY the JSON object, no markdown formatting, no code blocks, no addition
 
             return []
 
-    def describe_source(self, filters: FinancialDataFilters, record_count: int) -> Source:
+    def describe_source(self, results: List[FinancialDataRecord]) -> Source:
         """Describe the dataset read for this answer.
 
-        Honest provenance for a financial figure is the table plus the filters
-        applied. The table carries no reference to the statement PDF a figure
-        was extracted from, so this deliberately stops at the query rather than
-        implying a document-level citation it cannot support.
+        `filters` describes the rows actually returned, not the filters the
+        parser produced. Those two diverge badly: `_post_process_filters`
+        expands a company into its symbols, and because the source table holds
+        thousands of rows with a blank Company, a blank value matches every
+        symbol in the dataset. A single-company query therefore reports ~100
+        symbols in `filters_used` — accurate as a record of the SQL, useless
+        and actively misleading as a citation.
+
+        Describing what came back is both truthful and naturally bounded. The
+        parser's raw output is still available to callers as `filters_used`.
+
+        The table carries no reference to the statement PDF a figure was
+        extracted from, so this stops at the query rather than implying a
+        document-level citation it cannot support.
         """
+
+        def distinct(attr: str) -> List[str]:
+            values = {
+                str(getattr(record, attr)).strip()
+                for record in results
+                if getattr(record, attr, None) is not None and str(getattr(record, attr)).strip()
+            }
+            return sorted(values)
+
         return Source(
             type=SourceType.DATASET,
             title="JSE financial statements dataset",
             detail="Figures read directly from the JSE financial statements table",
             table=f"{self.project_id}.{self.dataset}.{self.table}",
             filters={
-                "companies": list(filters.companies or []),
-                "symbols": list(filters.symbols or []),
-                "years": list(filters.years or []),
-                "standard_items": list(filters.standard_items or []),
+                "companies": distinct("company"),
+                "symbols": distinct("symbol"),
+                "years": distinct("year"),
+                "standard_items": distinct("standard_item"),
             },
-            record_count=record_count,
+            record_count=len(results),
             retrieved_at=datetime.now(timezone.utc).isoformat(),
         )
 

--- a/fastapi_app/app/interaction_log.py
+++ b/fastapi_app/app/interaction_log.py
@@ -48,7 +48,59 @@ INTERACTIONS_SCHEMA = [
     bigquery.SchemaField("record_count", "INTEGER", mode="NULLABLE"),
     bigquery.SchemaField("success", "BOOLEAN", mode="REQUIRED"),
     bigquery.SchemaField("error_message", "STRING", mode="NULLABLE"),
+    # Provenance returned to the caller. `source_count` is denormalised on
+    # purpose: "what share of answers cited nothing" is the grounding-failure
+    # signal, and it should not require an UNNEST to ask.
+    bigquery.SchemaField("source_count", "INTEGER", mode="NULLABLE"),
+    bigquery.SchemaField(
+        "sources",
+        "RECORD",
+        mode="REPEATED",
+        fields=[
+            bigquery.SchemaField("type", "STRING", mode="NULLABLE"),
+            bigquery.SchemaField("title", "STRING", mode="NULLABLE"),
+            bigquery.SchemaField("url", "STRING", mode="NULLABLE"),
+            bigquery.SchemaField("domain", "STRING", mode="NULLABLE"),
+            bigquery.SchemaField("document_id", "STRING", mode="NULLABLE"),
+            bigquery.SchemaField("company", "STRING", mode="NULLABLE"),
+            bigquery.SchemaField("year", "STRING", mode="NULLABLE"),
+            bigquery.SchemaField("table", "STRING", mode="NULLABLE"),
+            bigquery.SchemaField("record_count", "INTEGER", mode="NULLABLE"),
+        ],
+    ),
 ]
+
+# Source fields carried into the log. `detail` and `retrieved_at` are
+# deliberately excluded: `detail` is model-generated prose with little
+# analytical value, and `retrieved_at` is within milliseconds of the row's
+# own `timestamp`.
+_LOGGED_SOURCE_FIELDS = (
+    "type",
+    "title",
+    "url",
+    "domain",
+    "document_id",
+    "company",
+    "year",
+    "table",
+    "record_count",
+)
+
+
+def _normalize_sources(sources: Optional[list]) -> list:
+    """Flatten Source models (or plain dicts) into BigQuery RECORD rows.
+
+    Both shapes reach this function: the fresh request path hands over
+    `Source` objects, while a `/chat/stream` cache hit hands over the raw
+    dicts read back from Redis.
+    """
+    if not sources:
+        return []
+    rows = []
+    for source in sources:
+        data = source.model_dump() if hasattr(source, "model_dump") else dict(source)
+        rows.append({field: data.get(field) for field in _LOGGED_SOURCE_FIELDS})
+    return rows
 
 
 class InteractionLogger:
@@ -94,6 +146,7 @@ class InteractionLogger:
         success: bool = True,
         error_message: Optional[str] = None,
         timestamp: Optional[str] = None,
+        sources: Optional[list] = None,
     ) -> Dict[str, Any]:
         """Build a row dict matching INTERACTIONS_SCHEMA. Caller supplies `timestamp`
         (ISO string) since this module avoids datetime.now() for testability."""
@@ -122,6 +175,10 @@ class InteractionLogger:
             "record_count": record_count,
             "success": success,
             "error_message": error_message,
+            # None (a failed request) and [] (a request that succeeded but
+            # cited nothing) are different facts, so they stay distinguishable.
+            "source_count": len(sources) if sources is not None else None,
+            "sources": _normalize_sources(sources),
         }
 
     async def log(self, row: Dict[str, Any]) -> None:

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -717,9 +717,7 @@ async def fast_chat_v2(
                         f"Generated {chart_data['chart_type']} chart: {chart_data['title']}"
                     )
 
-            sources = (
-                [financial_manager.describe_source(filters, len(results))] if results else None
-            )
+            sources = [financial_manager.describe_source(results)] if results else None
 
             if trace_obs is not None:
                 trace_obs.update(output=ai_response, metadata={"cache_hit": False})

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -645,6 +645,7 @@ async def fast_chat_v2(
                 success=True,
                 data_found=data_found,
                 record_count=record_count,
+                sources=sources,
             )
             return FinancialDataResponse(
                 response=ai_response,
@@ -754,6 +755,7 @@ async def fast_chat_v2(
             output_tokens=sum(c.token_usage.output_tokens for c in request_costs),
             cost_usd=sum(c.total_cost for c in request_costs),
             phase_costs=[c.phase for c in request_costs],
+            sources=sources,
         )
         return FinancialDataResponse(
             response=ai_response,
@@ -985,6 +987,7 @@ async def chat_stream(
                 success=True,
                 data_found=cached["data_found"],
                 record_count=cached["record_count"],
+                sources=cached.get("sources"),
             )
             return AgentChatResponse(
                 response=cached["response"],
@@ -1082,6 +1085,7 @@ async def chat_stream(
             output_tokens=cost_summary.total_output_tokens if cost_summary else 0,
             cost_usd=cost_summary.total_cost_usd if cost_summary else 0.0,
             phase_costs=[p.phase for p in cost_summary.phases] if cost_summary else None,
+            sources=response.sources,
         )
 
         return response

--- a/fastapi_app/tests/unit/test_dataset_source.py
+++ b/fastapi_app/tests/unit/test_dataset_source.py
@@ -1,9 +1,16 @@
 """Unit tests for dataset provenance on /fast_chat_v2.
 
-A financial figure's honest provenance is the table it came from plus the
-filters applied — not a fabricated per-number URL. See the known limitation
-in the design doc: the table has no column pointing back to the statement
-PDF, so a dataset source deliberately stops at the query.
+A financial figure's honest provenance is the table it came from plus a
+description of the rows read — not a fabricated per-number URL. See the known
+limitation in the design doc: the table has no column pointing back to the
+statement PDF, so a dataset source deliberately stops at the query.
+
+`filters` describes the rows actually returned rather than the parser's
+filters. Those diverge badly in practice: `_post_process_filters` expands a
+company into its symbols, and the source table holds thousands of rows with a
+blank Company, so a blank value matches every symbol in the dataset. A
+single-company query reports ~100 symbols in `filters_used` — accurate as a
+record of the SQL, misleading as a citation.
 """
 
 from unittest.mock import patch
@@ -11,7 +18,7 @@ from unittest.mock import patch
 import pytest
 
 from app.financial_utils import FinancialDataManager
-from app.models import FinancialDataFilters, SourceType
+from app.models import FinancialDataRecord, SourceType
 
 
 @pytest.fixture
@@ -24,49 +31,91 @@ def manager():
     return mgr
 
 
+def _record(
+    company="NCB Financial Group Limited",
+    symbol="NCBFG",
+    year="2023",
+    item_name="net_profit",
+    value=2507191000.0,
+):
+    return FinancialDataRecord(
+        company=company,
+        symbol=symbol,
+        year=year,
+        standard_item=item_name,
+        item=value,
+        unit_multiplier=1,
+        formatted_value="2.51B",
+    )
+
+
 @pytest.mark.unit
 class TestDescribeSource:
     def test_source_is_typed_dataset(self, manager):
-        source = manager.describe_source(FinancialDataFilters(), 0)
-        assert source.type == SourceType.DATASET
+        assert manager.describe_source([]).type == SourceType.DATASET
 
     def test_table_is_fully_qualified(self, manager):
-        source = manager.describe_source(FinancialDataFilters(), 3)
-        assert source.table == "jse-proj.financials.statements"
+        assert manager.describe_source([_record()]).table == "jse-proj.financials.statements"
 
-    def test_record_count_is_carried(self, manager):
-        source = manager.describe_source(FinancialDataFilters(), 42)
-        assert source.record_count == 42
+    def test_record_count_matches_rows_read(self, manager):
+        assert manager.describe_source([_record(), _record(year="2022")]).record_count == 2
 
-    def test_only_query_shaping_filters_are_included(self, manager):
-        """Conversational fields describe interpretation, not what was read."""
-        filters = FinancialDataFilters(
-            companies=["NCB Financial Group"],
-            symbols=["NCBFG"],
-            years=["2023"],
-            standard_items=["net_profit"],
-            interpretation="user wants NCB net profit",
-            is_follow_up=True,
-            context_used="previous turn",
-            data_availability_note="note",
-            unrecognized_items=["ebitda"],
-        )
-        source = manager.describe_source(filters, 4)
+    def test_filters_describe_the_rows_returned(self, manager):
+        source = manager.describe_source([_record()])
         assert source.filters == {
-            "companies": ["NCB Financial Group"],
+            "companies": ["NCB Financial Group Limited"],
             "symbols": ["NCBFG"],
             "years": ["2023"],
             "standard_items": ["net_profit"],
         }
 
+    def test_values_are_deduped_and_sorted(self, manager):
+        source = manager.describe_source(
+            [
+                _record(year="2023"),
+                _record(year="2022"),
+                _record(year="2023"),
+                _record(company="GraceKennedy Limited", symbol="GK", year="2024"),
+            ]
+        )
+        assert source.filters["years"] == ["2022", "2023", "2024"]
+        assert source.filters["symbols"] == ["GK", "NCBFG"]
+        assert source.filters["companies"] == [
+            "GraceKennedy Limited",
+            "NCB Financial Group Limited",
+        ]
+
+    def test_blank_values_are_excluded(self, manager):
+        """The source table holds thousands of blank-Company rows; a blank is
+        never meaningful provenance."""
+        source = manager.describe_source([_record(), _record(company="", symbol="   ")])
+        assert source.filters["companies"] == ["NCB Financial Group Limited"]
+        assert source.filters["symbols"] == ["NCBFG"]
+
+    def test_does_not_report_the_whole_symbol_universe(self, manager):
+        """Regression guard for the bug this replaced: a one-company answer
+        must not claim ~100 symbols just because the parser expanded them."""
+        source = manager.describe_source([_record()])
+        assert source.filters["symbols"] == ["NCBFG"]
+        assert len(source.filters["symbols"]) == 1
+
+    def test_empty_results_produce_empty_filters(self, manager):
+        source = manager.describe_source([])
+        assert source.record_count == 0
+        assert source.filters == {
+            "companies": [],
+            "symbols": [],
+            "years": [],
+            "standard_items": [],
+        }
+
     def test_title_names_the_dataset_readably(self, manager):
-        source = manager.describe_source(FinancialDataFilters(), 1)
+        source = manager.describe_source([_record()])
         assert source.title
         assert "jse-proj" not in source.title  # a title, not a table id
 
     def test_retrieved_at_is_populated(self, manager):
-        source = manager.describe_source(FinancialDataFilters(), 1)
-        assert source.retrieved_at is not None
+        assert manager.describe_source([_record()]).retrieved_at is not None
 
 
 @pytest.mark.unit
@@ -78,9 +127,9 @@ class TestSourceCacheRoundTrip:
         from app.main import _jsonable
         from app.models import Source
 
-        source = manager.describe_source(FinancialDataFilters(companies=["NCB"], years=["2023"]), 5)
+        source = manager.describe_source([_record(), _record(year="2022")])
         payload = json.loads(json.dumps(_jsonable([source])))
         restored = [Source(**item) for item in payload]
         assert restored[0].table == source.table
         assert restored[0].filters == source.filters
-        assert restored[0].record_count == 5
+        assert restored[0].record_count == 2

--- a/fastapi_app/tests/unit/test_interaction_log.py
+++ b/fastapi_app/tests/unit/test_interaction_log.py
@@ -111,3 +111,96 @@ def test_build_interaction_logger_passes_environment_through():
     with patch("app.config.get_config", return_value=mock_config):
         logger_ = build_interaction_logger()
     assert logger_._environment == "staging"
+
+
+# ---------------------------------------------------------------------------
+# Source provenance logging
+#
+# Sources reach build_row in two shapes: the fresh request path hands over
+# Source models, while a /chat/stream cache hit hands over the raw dicts read
+# back from Redis. Both must land as the same BigQuery RECORD rows.
+# ---------------------------------------------------------------------------
+
+
+def _row(**kwargs):
+    return InteractionLogger.build_row(endpoint="chat_stream", query="q", response="r", **kwargs)
+
+
+def test_build_row_flattens_source_models():
+    from app.models import Source, SourceType
+
+    row = _row(
+        sources=[
+            Source(
+                type=SourceType.WEB,
+                title="jamstockex.com",
+                url="https://x/y",
+                domain="jamstockex.com",
+            )
+        ]
+    )
+    assert row["source_count"] == 1
+    assert row["sources"] == [
+        {
+            "type": "web",
+            "title": "jamstockex.com",
+            "url": "https://x/y",
+            "domain": "jamstockex.com",
+            "document_id": None,
+            "company": None,
+            "year": None,
+            "table": None,
+            "record_count": None,
+        }
+    ]
+
+
+def test_build_row_accepts_plain_dicts_from_cache():
+    """A /chat/stream cache hit passes dicts, not models — same output."""
+    row = _row(sources=[{"type": "web", "title": "t", "url": "https://x", "domain": "x.com"}])
+    assert row["source_count"] == 1
+    assert row["sources"][0]["type"] == "web"
+    assert row["sources"][0]["document_id"] is None
+
+
+def test_build_row_drops_detail_and_retrieved_at():
+    """Excluded on purpose: prose with no analytical value, and a near-duplicate
+    of the row's own timestamp."""
+    row = _row(
+        sources=[
+            {
+                "type": "dataset",
+                "title": "JSE financials",
+                "detail": "why it was used",
+                "retrieved_at": "2026-08-17T00:00:00+00:00",
+                "table": "p.d.t",
+                "record_count": 4,
+            }
+        ]
+    )
+    assert "detail" not in row["sources"][0]
+    assert "retrieved_at" not in row["sources"][0]
+    assert row["sources"][0]["table"] == "p.d.t"
+    assert row["sources"][0]["record_count"] == 4
+
+
+def test_zero_sources_and_failure_are_distinguishable():
+    """[] means 'answered, cited nothing' — the grounding-failure signal.
+    None means 'the request failed', so source_count stays NULL."""
+    answered_without_sources = _row(sources=[])
+    failed = _row(sources=None, success=False)
+
+    assert answered_without_sources["source_count"] == 0
+    assert answered_without_sources["sources"] == []
+    assert failed["source_count"] is None
+    assert failed["sources"] == []
+
+
+def test_build_row_keys_match_declared_schema():
+    """Guards the drift this table has already suffered once."""
+    from app.interaction_log import INTERACTIONS_SCHEMA
+
+    declared = {f.name for f in INTERACTIONS_SCHEMA}
+    produced = set(_row(sources=[]).keys())
+    # `environment` is stamped in log(), not build_row()
+    assert produced == declared - {"environment"}


### PR DESCRIPTION
Stacked on #62. Two changes: log the sources we now return, and fix what a dataset citation actually says.

## 1. Log provenance to the `interactions` table

Sources were being returned to callers but never logged, so there was no way to analyse citation behaviour. Adds a `sources` REPEATED RECORD plus a denormalised `source_count`.

`source_count` is denormalised deliberately — "what share of answers cited nothing" is the grounding-failure signal, and it shouldn't need an `UNNEST` to ask.

`None` (request failed) and `[]` (answered, cited nothing) stay distinguishable: the former leaves `source_count` NULL.

`detail` and `retrieved_at` are excluded from the logged record — prose with little analytical value, and a near-duplicate of the row's own `timestamp`.

**The live dev table was migrated** additively via `ALTER TABLE ADD COLUMN` (26 → 28 columns). Existing rows get NULL and an empty array; nothing reading the table today notices.

Verified end to end against the deployed dev config:

```
endpoint       source_count   logged_rows   types
chat_stream    10             10            web
fast_chat_v2   1              1             dataset
```

```sql
SELECT s.type, s.domain, COUNT(*) AS citations
FROM `jse-datasphere.jse_raw_financial_data_dev_elroy.interactions`, UNNEST(sources) s
GROUP BY 1,2 ORDER BY citations DESC
```

## 2. A dataset citation now describes the rows read

`describe_source()` reported the parser's filters, and those diverge badly from reality. `_post_process_filters` expands a company into its symbols, and the source table holds **4,046 rows with a blank `Company`** — so a blank value matches every symbol in the dataset.

The result: *"What was NCB Financial Group net profit in 2023?"* returned one row, and cited **101 symbols and a blank company**. Accurate as a record of the SQL; misleading as a citation, and 101 array entries in every logged row.

It now derives `companies` / `symbols` / `years` / `standard_items` from the returned records — deduped, sorted, blanks excluded. Same query, after:

```json
{ "companies": ["NCB Financial Group Limited"], "symbols": ["NCBFG"],
  "years": ["2023"], "standard_items": ["net_profit"] }
```

`filters_used` still carries the raw parser output unchanged, so nothing is lost.

Note the underlying data-quality issue is untouched: 4,046 blank-Company rows in `multiyear_financial_data` are still there, and still inflate `filters_used`. That's a separate fix.

## Two known gaps

**`document` sources are never logged.** Interaction logging only covers `/fast_chat_v2` and `/chat/stream` — `/chat` has no `schedule_log` at all. So web and dataset citations are analysable; document ones aren't.

**The code schema had already drifted from the live table** before this change: `INTERACTIONS_SCHEMA` declares 23 columns while the live table had 26 (`thinking_tokens`, `finish_reason`, `truncated`, added by the in-flight `truncated-response-investigation` branch). A fresh environment built from `main` via `create_interactions_table.py` would get a table that branch's writes then fail against. A new test pins `build_row()` against the declared schema, but nothing pins the declared schema against the live table.

## Verification

- Suite **36 failed / 202 passed / 14 errors** — failures and errors identical to the branch point, so zero regressions. 9 new tests.
- `ruff` and `black` clean.
- Live local run confirming the corrected `filters`, and BigQuery rows confirmed landing with the right `source_count` and types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)