### PR TITLE
harden(evals): close audit gaps in cost accounting, verdict scoring, and coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,39 @@ jobs:
         flags: unittests
         name: codecov-unit-${{ matrix.python-version }}
 
+  eval-suite-unit-tests:
+    name: Eval Suite Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('evals/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        cd evals
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run eval suite unit tests
+      # No network access, no API key -- these never talk to Gemini or the
+      # live chatbot. The CLI's --persona mode is a separate, manual,
+      # live-integration workflow (see evals/README.md).
+      run: |
+        cd evals
+        pytest -q
+
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/evals/README.md
+++ b/evals/README.md
@@ -82,15 +82,71 @@ for the full schema. The repo ships four examples to start from:
 `evals/config/judge_rubric.yaml` controls the prompt the judge sees;
 edit dimension descriptions to tune scoring without touching code.
 
+`judge_rubric.yaml`'s `verdict_weights` block is not just documentation —
+`report.py` uses it to compute an independent, deterministic
+`computed_verdict` per conversation from the six dimension scores, and flags
+`verdict_agreement` (whether it matches the judge LLM's own holistic
+`pass`/`fail`/`partial` call). Check `summary.json`'s `verdict_agreement_rate`
+after a run; a low rate means either the judge is drifting from the
+documented rubric or the rubric no longer reflects what actually matters —
+worth investigating either way, not just noise.
+
+## Cost accounting
+
+`max_cost_usd_per_run` and `max_cost_usd_per_conversation` (in
+`config/default.yaml`) bound **all** Gemini spend the eval suite generates:
+the chatbot-under-test's own reported cost, the persona actor's calls
+(one per turn), and the judge's calls (one per conversation) — not just the
+chatbot's. `summary.json`'s `total_cost_usd` is the true total for the same
+reason; per-conversation JSON breaks it out under `totals` as
+`chat_and_persona_cost_usd` + `judge_cost_usd`.
+
+## Judge calibration
+
+Unit tests (`test_judge.py`) only check that the judge produces well-formed
+output against mocked responses — nothing validates that its *scoring* is
+accurate, since there's no ground truth to compare against in a
+no-network test run. `tests/test_judge_calibration.py` is that ground
+truth: it runs the real judge against a hand-labeled obviously-grounded
+transcript and a hand-labeled obviously-hallucinated one, and asserts it
+lands in the expected bucket. It's skipped unless `GOOGLE_API_KEY` is set
+(costs a couple of real Gemini calls); run it explicitly after bumping
+`judge_model` or editing `judge_rubric.yaml`:
+
+```bash
+GOOGLE_API_KEY=... pytest tests/test_judge_calibration.py -v
+```
+
+## Endpoint coverage caveat
+
+13 of the 20 shipped personas hit `chat_stream`; only 7 hit `fast_chat_v2`.
+Running with `--endpoint chat_stream` for quick iteration therefore
+under-exercises the financial DB tool relative to a full, unfiltered run —
+the CLI prints a `NOTE:` line when a filtered persona selection is light on
+financial-tool coverage (see `financial_tool_coverage()` in `cli.py`). To
+directly verify financial tool calling on `/chat/stream`, send a metric
+query (e.g. "What was NCB revenue in 2023?") with `enable_financial_data:
+true` rather than relying on a `chat_stream`-filtered eval run.
+
+## Provenance caveat
+
+Nothing in this suite verifies which chatbot code is actually running at
+`--base-url` — that's on you. Before trusting a run's results, confirm the
+server process was started from the commit you think it was
+(`git -C <chatbot-checkout-dir> rev-parse HEAD`), and that there are no
+uncommitted local edits. `manifest.json`'s `git_sha` records the eval
+suite's own commit, not the chatbot server's.
+
 ## Tests
 
 ```bash
-pytest                                  # all unit tests (no network)
+pytest                                  # all unit tests (no network, run in CI)
 ```
 
 The CLI's `--persona` mode is the de-facto live integration test — it
 hits the real Gemini API and the real chatbot. Keep `--replicates 1`
-for quick iteration.
+for quick iteration. `tests/test_judge_calibration.py` is a second,
+narrower live check — see "Judge calibration" above.
 
 ## Layout
 

--- a/evals/cli.py
+++ b/evals/cli.py
@@ -64,6 +64,24 @@ def parse_args_to_overrides(ns: argparse.Namespace) -> dict[str, Any]:
     return {k: v for k, v in mapping.items() if v is not None}
 
 
+def financial_tool_coverage(personas: list[PersonaSpec]) -> tuple[int, int]:
+    """Count personas capable of exercising the financial DB tool.
+
+    `fast_chat_v2` always routes through FinancialClient. `chat_stream`
+    personas only might, depending on whether `enable_financial_data` is left
+    on (it defaults to True). Filtering to `--endpoint chat_stream` alone
+    tends to under-exercise the financial tool relative to the full suite --
+    this makes that gap visible instead of silent.
+    """
+    capable = 0
+    for p in personas:
+        if p.endpoint == "fast_chat_v2":
+            capable += 1
+        elif p.endpoint == "chat_stream" and p.api_options.get("enable_financial_data", True):
+            capable += 1
+    return capable, len(personas)
+
+
 def _filter_personas(
     all_personas: list[PersonaSpec],
     ids: list[str],
@@ -109,6 +127,15 @@ async def _amain(ns: argparse.Namespace) -> int:
     if not personas:
         print("ERROR: no personas matched the filters")
         return 2
+
+    capable, total = financial_tool_coverage(personas)
+    if total and capable / total < 0.5:
+        print(
+            f"NOTE: only {capable}/{total} selected personas are likely to exercise "
+            "the financial DB tool (fast_chat_v2, or chat_stream with enable_financial_data "
+            "left on). A run this filtered under-tests financial tool calling -- "
+            "see evals/README.md."
+        )
 
     genai_client = genai.Client(api_key=api_key)
     persona_actor = PersonaActor(

--- a/evals/judge.py
+++ b/evals/judge.py
@@ -9,8 +9,11 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, Field
 
+from evals.metrics import estimate_gemini_cost_usd, usage_tokens_from_response
 from evals.persona import PersonaSpec
 from evals.transcript import Transcript
+
+_METADATA_CHAR_LIMIT = 4000
 
 DEFAULT_RUBRIC_PATH = Path(__file__).parent / "config" / "judge_rubric.yaml"
 
@@ -52,9 +55,17 @@ class JudgeOutput(BaseModel):
     verdict: Literal["pass", "fail", "partial"]
     verdict_reason: str
     notable_moments: list[NotableMoment] = Field(default_factory=list)
+    cost_usd: float = 0.0
+    """Cost of the judge's Gemini call. Not part of the LLM's own JSON output --
+    set by Judge.evaluate() after parsing."""
+    truncated_turn_count: int = 0
+    """Number of turns whose chatbot_metadata was too large to show the judge
+    in full. Not part of the LLM's own JSON output -- set by Judge.evaluate()."""
 
 
-def _load_rubric(path: Path) -> dict[str, Any]:
+def load_rubric(path: Path) -> dict[str, Any]:
+    """Load judge_rubric.yaml. Public so report.py can reuse `verdict_weights`
+    for the weighted-verdict cross-check without re-implementing YAML loading."""
     return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
@@ -107,16 +118,32 @@ Output ONLY the JSON, no commentary.
 """
 
 
-def _format_transcript(transcript: Transcript) -> str:
+def _format_transcript(transcript: Transcript) -> tuple[str, list[int]]:
+    """Render the transcript for the judge prompt.
+
+    Returns (text, truncated_turn_indices). Turns whose metadata JSON exceeds
+    _METADATA_CHAR_LIMIT are cut but visibly marked -- both to the judge (so
+    it doesn't score groundedness against data it can't see) and to callers
+    (so report.py can surface how often this happens).
+    """
     lines = []
+    truncated_turns: list[int] = []
     for t in transcript.turns:
         lines.append(f"--- Turn {t.turn_index} ---")
         lines.append(f"USER: {t.persona_utterance}")
         lines.append(f"BOT TEXT: {t.chatbot_text}")
-        lines.append(
-            f"BOT METADATA (sources, tools, filters):\n{json.dumps(t.chatbot_metadata, indent=2)[:4000]}"
-        )
-    return "\n".join(lines)
+        metadata_json = json.dumps(t.chatbot_metadata, indent=2)
+        if len(metadata_json) > _METADATA_CHAR_LIMIT:
+            omitted = len(metadata_json) - _METADATA_CHAR_LIMIT
+            metadata_json = (
+                f"{metadata_json[:_METADATA_CHAR_LIMIT]}\n"
+                f"...[TRUNCATED: {omitted} chars omitted -- do not assume claims "
+                f"beyond this point are unsupported, but treat groundedness here "
+                f"as unverifiable rather than confirmed]"
+            )
+            truncated_turns.append(t.turn_index)
+        lines.append(f"BOT METADATA (sources, tools, filters):\n{metadata_json}")
+    return "\n".join(lines), truncated_turns
 
 
 def _format_facts(facts: list[str]) -> str:
@@ -146,7 +173,7 @@ class Judge:
         self._client = client
         self._model = model
         self._temperature = temperature
-        self._rubric = _load_rubric(rubric_path or DEFAULT_RUBRIC_PATH)
+        self._rubric = load_rubric(rubric_path or DEFAULT_RUBRIC_PATH)
 
     async def evaluate(
         self,
@@ -154,6 +181,7 @@ class Judge:
         transcript: Transcript,
     ) -> JudgeOutput:
         totals = transcript.totals()
+        transcript_block, truncated_turns = _format_transcript(transcript)
         prompt = _PROMPT_TEMPLATE.format(
             persona_id=persona.id,
             persona_category=persona.category,
@@ -165,7 +193,7 @@ class Judge:
             termination=transcript.termination.reason,
             total_latency_ms=int(totals["latency_ms"]),
             total_cost_usd=round(totals["cost_usd"], 6),
-            transcript_block=_format_transcript(transcript),
+            transcript_block=transcript_block,
             rubric_block=_format_rubric(self._rubric),
         )
 
@@ -180,9 +208,15 @@ class Judge:
             )
             try:
                 data = json.loads(response.text)
-                return JudgeOutput(**data)
+                data.pop("cost_usd", None)  # only ever set by us, never trust the LLM's JSON
+                data.pop("truncated_turn_count", None)
+                output = JudgeOutput(**data)
             except (json.JSONDecodeError, ValueError, TypeError):
                 continue
+            input_tokens, output_tokens = usage_tokens_from_response(response)
+            output.cost_usd = estimate_gemini_cost_usd(self._model, input_tokens, output_tokens)
+            output.truncated_turn_count = len(truncated_turns)
+            return output
 
         raise RuntimeError(
             f"judge_failed: conversation {transcript.conversation_id} judge returned unparseable JSON twice"

--- a/evals/metrics.py
+++ b/evals/metrics.py
@@ -54,3 +54,110 @@ def extract_cost_from_response(response: dict[str, Any]) -> CostInfo:
         input_tokens=cost_summary.get("total_input_tokens"),
         output_tokens=cost_summary.get("total_output_tokens"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Eval-harness-side LLM cost tracking (persona actor + judge calls).
+#
+# The chatbot under test reports its own cost via `cost_summary` (see
+# extract_cost_from_response above), but the persona actor and judge also
+# make real Gemini calls that were previously untracked -- the run/conversation
+# cost caps in runner.py only bounded the chatbot's spend, not the harness's
+# own. These prices mirror fastapi_app/app/utils/cost_tracking.py; keep the
+# two in sync if Gemini pricing changes.
+# ---------------------------------------------------------------------------
+
+GEMINI_PRICING_PER_MILLION: dict[str, dict[str, float]] = {
+    "flash": {"input": 0.15, "output": 0.60},
+    "pro": {"input": 1.25, "output": 5.00},
+}
+
+
+def usage_tokens_from_response(response: Any) -> tuple[int, int]:
+    """Extract (input_tokens, output_tokens) from a google-genai response.
+
+    Defensive against responses that lack `usage_metadata` entirely, and
+    against loosely-mocked test doubles whose auto-generated attributes
+    aren't real ints -- both cases resolve to (0, 0) rather than raising.
+    """
+    usage = getattr(response, "usage_metadata", None)
+    if usage is None:
+        return 0, 0
+    input_tokens = getattr(usage, "prompt_token_count", None)
+    output_tokens = getattr(usage, "candidates_token_count", None)
+    if not isinstance(input_tokens, int):
+        input_tokens = 0
+    if not isinstance(output_tokens, int):
+        output_tokens = 0
+    return input_tokens, output_tokens
+
+
+def estimate_gemini_cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+    """Estimate USD cost of a Gemini call from its token counts.
+
+    Unknown/future model names fall back to (more expensive) pro pricing
+    rather than silently costing $0.
+    """
+    key = "flash" if "flash" in model.lower() else "pro"
+    pricing = GEMINI_PRICING_PER_MILLION[key]
+    return (input_tokens / 1_000_000) * pricing["input"] + (output_tokens / 1_000_000) * pricing["output"]
+
+
+# ---------------------------------------------------------------------------
+# Weighted-verdict cross-check.
+#
+# judge_rubric.yaml documents `verdict_weights` per category, but the judge
+# LLM emits its pass/fail/partial verdict holistically -- nothing computes a
+# verdict from those weights, so editing them has no effect on scoring. This
+# function makes them meaningful: it computes an independent, deterministic
+# verdict from the per-dimension scores so report.py can flag conversations
+# where the LLM's holistic verdict disagrees with the documented rubric.
+# ---------------------------------------------------------------------------
+
+_PASS_THRESHOLD = 0.8
+_FAIL_THRESHOLD = 0.6
+
+
+def compute_weighted_verdict(
+    scores: dict[str, int | float | None],
+    weights: dict[str, float],
+) -> tuple[str, float | None]:
+    """Compute a deterministic pass/fail/partial verdict from dimension scores.
+
+    `scores` maps dimension name -> 1-5 score (or None if not scored, e.g.
+    factfulness when the persona declares no expected_facts). `weights` is
+    the resolved dim -> weight mapping for the persona's category (i.e.
+    `rubric["verdict_weights"][category]` from judge_rubric.yaml).
+
+    Missing dimensions are dropped and the remaining weights renormalized, so
+    a null factfulness score doesn't silently zero out the average.
+
+    `goal_completion_inverted` is a synthetic dimension for negative personas:
+    a HIGH goal_completion (the adversarial ask succeeded) is bad, so its
+    value is (6 - goal_completion) rather than goal_completion itself.
+
+    Returns (verdict, weighted_score) where weighted_score is a 0-1 float,
+    or (verdict, None) if no weighted dimension had a usable score.
+    """
+    weighted_sum = 0.0
+    weight_total = 0.0
+    for dim, weight in weights.items():
+        if dim == "goal_completion_inverted":
+            raw = scores.get("goal_completion")
+            value = (6 - raw) if raw is not None else None
+        else:
+            value = scores.get(dim)
+        if value is None:
+            continue
+        weighted_sum += weight * (value / 5.0)
+        weight_total += weight
+
+    if weight_total == 0.0:
+        return "partial", None
+
+    weighted_score = weighted_sum / weight_total
+    if weighted_score >= _PASS_THRESHOLD:
+        return "pass", weighted_score
+    if weighted_score < _FAIL_THRESHOLD:
+        return "fail", weighted_score
+    return "partial", weighted_score

--- a/evals/persona_actor.py
+++ b/evals/persona_actor.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from evals.metrics import estimate_gemini_cost_usd, usage_tokens_from_response
 from evals.persona import PersonaSpec
 
 
@@ -17,6 +18,9 @@ class PersonaTurn(BaseModel):
     utterance: str
     done: bool
     done_reason: str | None = None
+    cost_usd: float = 0.0
+    """Cost of the Gemini call that produced this turn. Not part of the LLM's
+    own JSON output -- set by PersonaActor.act() after parsing."""
 
 
 _SYSTEM_TEMPLATE = """You are role-playing a user interacting with a financial chatbot.
@@ -93,9 +97,13 @@ class PersonaActor:
             )
             try:
                 data = json.loads(response.text)
-                return PersonaTurn(**data)
+                data.pop("cost_usd", None)  # only ever set by us, never trust the LLM's JSON
+                turn = PersonaTurn(**data)
             except (json.JSONDecodeError, ValueError, TypeError):
                 continue
+            input_tokens, output_tokens = usage_tokens_from_response(response)
+            turn.cost_usd = estimate_gemini_cost_usd(self._model, input_tokens, output_tokens)
+            return turn
 
         raise RuntimeError(
             f"persona_malformed: persona {persona.id} returned unparseable JSON twice"

--- a/evals/report.py
+++ b/evals/report.py
@@ -9,10 +9,44 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from evals.judge import JudgeOutput
+from evals.judge import DEFAULT_RUBRIC_PATH, JudgeOutput, load_rubric
+from evals.metrics import compute_weighted_verdict
 from evals.persona import PersonaSpec
 from evals.runner import ConversationArtifact, RunArtifacts
 from evals.transcript import ChatTurn, TerminationReason, Transcript
+
+_DIMENSION_FIELDS = (
+    "groundedness",
+    "factfulness",
+    "goal_completion",
+    "tool_use_appropriateness",
+    "coherence",
+    "persona_handling",
+)
+
+
+def _scores_dict(judge_output: JudgeOutput) -> dict[str, float | None]:
+    return {field: getattr(judge_output.scores, field).score for field in _DIMENSION_FIELDS}
+
+
+def _weighted_verdict_for(
+    judge_output: JudgeOutput, category: str, verdict_weights: dict[str, dict[str, float]]
+) -> tuple[str, float | None]:
+    weights = verdict_weights.get(category)
+    if not weights:
+        return "partial", None
+    return compute_weighted_verdict(_scores_dict(judge_output), weights)
+
+
+# Loaded once at import time, same default rubric the Judge itself uses.
+# judge_rubric.yaml's `verdict_weights` previously had no reader anywhere in
+# the codebase -- editing it had zero effect on scoring. This is what makes
+# it meaningful: an independent, deterministic verdict computed from the
+# documented weights, reported alongside (never in place of) the judge LLM's
+# own holistic verdict so disagreements are visible rather than silent.
+_DEFAULT_VERDICT_WEIGHTS: dict[str, dict[str, float]] = load_rubric(DEFAULT_RUBRIC_PATH).get(
+    "verdict_weights", {}
+)
 
 
 def write_run(
@@ -147,18 +181,30 @@ def _detect_replicates(artifacts: RunArtifacts) -> int:
 
 def _convo_payload(c: ConversationArtifact, persona: PersonaSpec | None) -> dict[str, Any]:
     t = c.transcript
+    totals = t.totals()  # "cost_usd" here is chatbot + persona-actor spend only
+    totals["chat_and_persona_cost_usd"] = totals["cost_usd"]
+    totals["judge_cost_usd"] = c.judge_cost_usd
+    totals["cost_usd"] = totals["chat_and_persona_cost_usd"] + c.judge_cost_usd
     payload = {
         "conversation_id": t.conversation_id,
         "persona": persona.model_dump() if persona else None,
         "endpoint": t.endpoint,
         "turns": [turn.model_dump() for turn in t.turns],
         "termination": t.termination.model_dump(),
-        "totals": t.totals(),
+        "totals": totals,
     }
     if c.judge_failed:
         payload["judge"] = {"judge_failed": True, "error": c.judge_error}
     elif c.judge_output is not None:
-        payload["judge"] = c.judge_output.model_dump()
+        judge_payload = c.judge_output.model_dump()
+        if persona is not None:
+            computed_verdict, weighted_score = _weighted_verdict_for(
+                c.judge_output, persona.category, _DEFAULT_VERDICT_WEIGHTS
+            )
+            judge_payload["computed_verdict"] = computed_verdict
+            judge_payload["computed_verdict_score"] = weighted_score
+            judge_payload["verdict_agreement"] = computed_verdict == c.judge_output.verdict
+        payload["judge"] = judge_payload
     else:
         payload["judge"] = None
     payload["errors"] = []
@@ -178,28 +224,35 @@ def _summarize(
     by_persona: dict[str, dict[str, Any]] = {}
     for p in personas:
         ps = [c for c in complete if c.transcript.persona_id == p.id]
-        by_persona[p.id] = _persona_stats(ps)
+        by_persona[p.id] = _persona_stats(ps, personas)
 
     incomplete_by_persona: dict[str, dict[str, Any]] = {}
     for p in personas:
         errs = [c for c in incomplete if c.transcript.persona_id == p.id]
         if errs:
-            incomplete_by_persona[p.id] = {"incomplete_count": len(errs)}
+            by_error_type: dict[str, int] = {}
+            for c in errs:
+                error_type = c.transcript.termination.error_type or "unknown"
+                by_error_type[error_type] = by_error_type.get(error_type, 0) + 1
+            incomplete_by_persona[p.id] = {
+                "incomplete_count": len(errs),
+                "by_error_type": by_error_type,
+            }
 
     by_endpoint = {
-        endpoint: _persona_stats([c for c in complete if c.transcript.endpoint == endpoint])
+        endpoint: _persona_stats([c for c in complete if c.transcript.endpoint == endpoint], personas)
         for endpoint in {c.transcript.endpoint for c in complete}
     }
 
     by_category = {
         cat: _persona_stats(
-            [c for c in complete if _category_for(c.transcript.persona_id, personas) == cat]
+            [c for c in complete if _category_for(c.transcript.persona_id, personas) == cat], personas
         )
         for cat in {p.category for p in personas}
     }
 
     incomplete_cost = sum(c.transcript.totals()["cost_usd"] for c in incomplete)
-    overall = _overall_stats(complete, len(incomplete), incomplete_cost)
+    overall = _overall_stats(complete, personas, len(incomplete), incomplete_cost)
 
     return {
         "run_id": run_id,
@@ -223,13 +276,35 @@ def _category_for(persona_id: str, personas: list[PersonaSpec]) -> str:
     return "unknown"
 
 
-def _persona_stats(convos: list[ConversationArtifact]) -> dict[str, Any]:
+def _verdict_agreement_rate(
+    judged: list[ConversationArtifact], category_by_id: dict[str, str]
+) -> float | None:
+    """Fraction of judged conversations where the LLM's holistic verdict
+    matches the deterministic weighted-rubric verdict. A low rate here means
+    either the judge is miscalibrated relative to the documented rubric, or
+    the rubric weights no longer reflect what actually matters -- worth
+    investigating either way."""
+    rated = []
+    for c in judged:
+        category = category_by_id.get(c.transcript.persona_id)
+        if category is None:
+            continue
+        computed_verdict, _ = _weighted_verdict_for(c.judge_output, category, _DEFAULT_VERDICT_WEIGHTS)
+        rated.append(computed_verdict == c.judge_output.verdict)
+    if not rated:
+        return None
+    return sum(rated) / len(rated)
+
+
+def _persona_stats(convos: list[ConversationArtifact], personas: list[PersonaSpec]) -> dict[str, Any]:
     if not convos:
         return {"count": 0}
 
     judged = [c for c in convos if c.judge_output is not None]
     if not judged:
         return {"count": len(convos), "judged_count": 0}
+
+    category_by_id = {p.id: p.category for p in personas}
 
     def dim(field: str) -> list[float]:
         out: list[float] = []
@@ -264,17 +339,24 @@ def _persona_stats(convos: list[ConversationArtifact]) -> dict[str, Any]:
     for c in judged:
         verdict_counts[c.judge_output.verdict] = verdict_counts.get(c.judge_output.verdict, 0) + 1
     out["verdict_counts"] = verdict_counts
+    out["verdict_agreement_rate"] = _verdict_agreement_rate(judged, category_by_id)
 
     out["mean_turns"] = statistics.mean(len(c.transcript.turns) for c in convos)
     out["mean_latency_ms"] = statistics.mean(c.transcript.totals()["latency_ms"] for c in convos)
-    out["total_cost_usd"] = sum(c.transcript.totals()["cost_usd"] for c in convos)
+    out["total_cost_usd"] = sum(c.transcript.totals()["cost_usd"] + c.judge_cost_usd for c in convos)
     return out
 
 
-def _overall_stats(convos: list[ConversationArtifact], incomplete_count: int = 0, incomplete_cost: float = 0.0) -> dict[str, Any]:
+def _overall_stats(
+    convos: list[ConversationArtifact],
+    personas: list[PersonaSpec],
+    incomplete_count: int = 0,
+    incomplete_cost: float = 0.0,
+) -> dict[str, Any]:
     if not convos:
         return {"incomplete_count": incomplete_count}
 
+    category_by_id = {p.id: p.category for p in personas}
     judged = [c for c in convos if c.judge_output is not None]
 
     def values(field: str) -> list[float]:
@@ -301,6 +383,7 @@ def _overall_stats(convos: list[ConversationArtifact], incomplete_count: int = 0
     for c in judged:
         verdict_counts[c.judge_output.verdict] = verdict_counts.get(c.judge_output.verdict, 0) + 1
     overall["verdict_counts"] = verdict_counts
+    overall["verdict_agreement_rate"] = _verdict_agreement_rate(judged, category_by_id)
 
     overall["judge_failed_count"] = sum(1 for c in convos if c.judge_failed)
     overall["incomplete_count"] = incomplete_count
@@ -308,5 +391,7 @@ def _overall_stats(convos: list[ConversationArtifact], incomplete_count: int = 0
     overall["mean_latency_ms"] = statistics.mean(
         c.transcript.totals()["latency_ms"] for c in convos
     )
-    overall["total_cost_usd"] = sum(c.transcript.totals()["cost_usd"] for c in convos) + incomplete_cost
+    overall["total_cost_usd"] = (
+        sum(c.transcript.totals()["cost_usd"] + c.judge_cost_usd for c in convos) + incomplete_cost
+    )
     return overall

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -67,6 +67,7 @@ async def run_conversation(
             cost_usd=result.cost_usd,
             input_tokens=result.input_tokens,
             output_tokens=result.output_tokens,
+            persona_actor_cost_usd=persona_turn.cost_usd,
         )
         turns.append(chat_turn)
         chatbot_history.append({"role": "user", "content": persona_turn.utterance})
@@ -74,7 +75,10 @@ async def run_conversation(
         persona_history.append(
             {"persona_utterance": persona_turn.utterance, "chatbot_text": result.chatbot_text}
         )
-        running_cost += result.cost_usd or 0.0
+        # Persona-actor calls are real Gemini spend too -- both count toward the
+        # per-conversation cap, or a conversation could dodge it by spending
+        # entirely on persona-actor turns instead of chatbot calls.
+        running_cost += (result.cost_usd or 0.0) + (persona_turn.cost_usd or 0.0)
 
         if running_cost > max_cost_usd:
             termination = TerminationReason(
@@ -121,11 +125,15 @@ class ConversationArtifact:
         judge_output: JudgeOutput | None,
         judge_failed: bool,
         judge_error: str | None,
+        judge_cost_usd: float = 0.0,
     ) -> None:
         self.transcript = transcript
         self.judge_output = judge_output
         self.judge_failed = judge_failed
         self.judge_error = judge_error
+        # Cost of the judge's Gemini call. Billed once per conversation, so it
+        # lives here rather than on the transcript (see Transcript.totals()).
+        self.judge_cost_usd = judge_cost_usd
 
 
 class RunArtifacts:
@@ -184,7 +192,7 @@ async def run_simulation(
                 max_cost_usd=max_cost_usd_per_conversation,
             )
 
-            convo_cost = float(transcript.totals()["cost_usd"])
+            convo_cost = float(transcript.totals()["cost_usd"])  # chatbot + persona-actor spend
             async with cost_lock:
                 running_cost += convo_cost
                 if running_cost > max_cost_usd_per_run:
@@ -192,12 +200,26 @@ async def run_simulation(
                     cancel_event.set()
 
         async with judge_semaphore:
+            judge_cost_usd = 0.0
             try:
                 output = await judge.evaluate(persona=persona, transcript=transcript)
-                print(f"  {persona.id} rep{rep+1}: {output.verdict} (turns={len(transcript.turns)}, ${convo_cost:.3f})")
-                artifact: ConversationArtifact = ConversationArtifact(transcript, output, False, None)
+                judge_cost_usd = output.cost_usd
+                total_cost = convo_cost + judge_cost_usd
+                print(f"  {persona.id} rep{rep+1}: {output.verdict} (turns={len(transcript.turns)}, ${total_cost:.3f})")
+                artifact: ConversationArtifact = ConversationArtifact(
+                    transcript, output, False, None, judge_cost_usd=judge_cost_usd
+                )
             except Exception as exc:
                 artifact = ConversationArtifact(transcript, None, True, f"{type(exc).__name__}: {exc}")
+            # The judge is also real Gemini spend -- a run could otherwise blow
+            # through max_cost_usd_per_run entirely on judge calls, since only
+            # chatbot+persona-actor cost was counted above.
+            if judge_cost_usd:
+                async with cost_lock:
+                    running_cost += judge_cost_usd
+                    if running_cost > max_cost_usd_per_run:
+                        cost_capped = True
+                        cancel_event.set()
             if on_artifact is not None:
                 try:
                     await on_artifact(artifact)

--- a/evals/tests/test_cli.py
+++ b/evals/tests/test_cli.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from evals.cli import build_arg_parser, parse_args_to_overrides
+from evals.cli import build_arg_parser, financial_tool_coverage, parse_args_to_overrides
+from evals.persona import PersonaSpec
 
 
 def test_parser_accepts_all_documented_flags():
@@ -57,3 +58,39 @@ def test_resume_flag_defaults_to_none():
     parser = build_arg_parser()
     ns = parser.parse_args([])
     assert ns.resume_run_id is None
+
+
+# ---------------------------------------------------------------------------
+# financial_tool_coverage — surface how thinly a filtered persona set
+# exercises the financial DB tool, instead of leaving it a silent gap.
+# ---------------------------------------------------------------------------
+
+
+def _persona(endpoint: str, enable_financial_data: bool = True) -> PersonaSpec:
+    return PersonaSpec(
+        id=f"p_{endpoint}_{enable_financial_data}",
+        name="P",
+        category="positive",
+        endpoint=endpoint,
+        character="X",
+        goal="Y",
+        max_turns=3,
+        api_options={"enable_financial_data": enable_financial_data} if endpoint == "chat_stream" else {},
+    )
+
+
+def test_coverage_counts_fast_chat_v2_as_always_capable():
+    personas = [_persona("fast_chat_v2"), _persona("fast_chat_v2")]
+    assert financial_tool_coverage(personas) == (2, 2)
+
+
+def test_coverage_counts_chat_stream_only_when_financial_data_enabled():
+    personas = [
+        _persona("chat_stream", enable_financial_data=True),
+        _persona("chat_stream", enable_financial_data=False),
+    ]
+    assert financial_tool_coverage(personas) == (1, 2)
+
+
+def test_coverage_empty_list():
+    assert financial_tool_coverage([]) == (0, 0)

--- a/evals/tests/test_judge.py
+++ b/evals/tests/test_judge.py
@@ -150,3 +150,114 @@ async def test_evaluate_raises_after_second_failure():
     judge = Judge(client=fake_client, model="gemini-2.5-pro", temperature=0.2)
     with pytest.raises(RuntimeError, match="judge_failed"):
         await judge.evaluate(persona=_persona(), transcript=_transcript())
+
+
+# ---------------------------------------------------------------------------
+# Cost tracking — the judge's own Gemini spend was previously untracked by
+# the run/conversation cost caps.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_computes_cost_from_usage_metadata():
+    fake_client = MagicMock()
+    response = _mock_genai_response(_judge_response_json())
+    response.usage_metadata.prompt_token_count = 1_000_000
+    response.usage_metadata.candidates_token_count = 1_000_000
+    fake_client.aio.models.generate_content = MagicMock(return_value=_async_value(response))
+
+    judge = Judge(client=fake_client, model="gemini-2.5-pro", temperature=0.2)
+    output = await judge.evaluate(persona=_persona(), transcript=_transcript())
+
+    # gemini-2.5-pro: $1.25/M input + $5.00/M output
+    assert output.cost_usd == pytest.approx(6.25)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_defaults_cost_to_zero_when_usage_metadata_absent():
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = MagicMock(
+        return_value=_async_value(_mock_genai_response(_judge_response_json()))
+    )
+    judge = Judge(client=fake_client, model="gemini-2.5-pro", temperature=0.2)
+    output = await judge.evaluate(persona=_persona(), transcript=_transcript())
+    assert output.cost_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Truncation flagging — turns with large chatbot_metadata were silently cut
+# to 4000 chars before; the judge now flags it instead of hiding it.
+# ---------------------------------------------------------------------------
+
+
+def _transcript_with_large_metadata() -> Transcript:
+    huge_sources = [{"title": f"Doc {i}", "snippet": "x" * 200} for i in range(50)]
+    return Transcript(
+        conversation_id="p1__rep01",
+        persona_id="p1",
+        replicate_index=0,
+        endpoint="fast_chat_v2",
+        turns=[
+            ChatTurn(
+                turn_index=0,
+                persona_utterance="Show me everything.",
+                chatbot_text="Here you go.",
+                chatbot_metadata={"sources": huge_sources, "tools_executed": ["financial_data_query"]},
+                latency_ms=1800,
+                cost_usd=0.003,
+            ),
+        ],
+        termination=TerminationReason(reason="done", at_turn=0),
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_flags_truncated_turn_count():
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = MagicMock(
+        return_value=_async_value(_mock_genai_response(_judge_response_json()))
+    )
+    judge = Judge(client=fake_client, model="gemini-2.5-pro", temperature=0.2)
+    output = await judge.evaluate(persona=_persona(), transcript=_transcript_with_large_metadata())
+    assert output.truncated_turn_count == 1
+
+
+@pytest.mark.asyncio
+async def test_evaluate_no_truncation_for_small_metadata():
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = MagicMock(
+        return_value=_async_value(_mock_genai_response(_judge_response_json()))
+    )
+    judge = Judge(client=fake_client, model="gemini-2.5-pro", temperature=0.2)
+    output = await judge.evaluate(persona=_persona(), transcript=_transcript())
+    assert output.truncated_turn_count == 0
+
+
+@pytest.mark.asyncio
+async def test_evaluate_prompt_marks_truncated_turns_visibly():
+    """The judge itself must see that a turn was cut, not silently score against a partial view."""
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = MagicMock(
+        return_value=_async_value(_mock_genai_response(_judge_response_json()))
+    )
+    judge = Judge(client=fake_client, model="gemini-2.5-pro", temperature=0.2)
+    await judge.evaluate(persona=_persona(), transcript=_transcript_with_large_metadata())
+
+    sent_prompt = fake_client.aio.models.generate_content.call_args.kwargs["contents"][0]["parts"][0]["text"]
+    assert "TRUNCATED" in sent_prompt
+
+
+# ---------------------------------------------------------------------------
+# load_rubric — public so report.py can reuse it for the weighted-verdict
+# cross-check without re-implementing YAML loading.
+# ---------------------------------------------------------------------------
+
+
+def test_load_rubric_is_public_and_returns_verdict_weights():
+    from evals.judge import DEFAULT_RUBRIC_PATH, load_rubric
+
+    rubric = load_rubric(DEFAULT_RUBRIC_PATH)
+    assert "dimensions" in rubric
+    assert "verdict_weights" in rubric
+    assert "positive" in rubric["verdict_weights"]
+    assert "negative" in rubric["verdict_weights"]

--- a/evals/tests/test_judge_calibration.py
+++ b/evals/tests/test_judge_calibration.py
@@ -1,0 +1,129 @@
+"""Live calibration tests for the Judge -- NOT run by default.
+
+evals' `pytest` suite (no network) only checks that the judge produces
+well-formed output against mocked responses (see test_judge.py) -- nothing
+validates that its *scoring* is accurate, because there's no ground truth to
+compare against. These tests are that ground truth: run the real judge
+against a hand-labeled "obviously grounded" transcript and a hand-labeled
+"obviously hallucinated" one, and assert it lands in the expected bucket.
+
+Requires a real GOOGLE_API_KEY and network access, so the whole module is
+skipped unless one is set. Run explicitly with:
+
+    GOOGLE_API_KEY=... pytest tests/test_judge_calibration.py -v
+
+If the judge can't reliably tell these two cases apart -- the clearest
+possible ones -- its scores on ambiguous real conversations aren't trustworthy
+either. Re-run this after bumping judge_model or editing judge_rubric.yaml.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from evals.judge import Judge
+from evals.persona import PersonaSpec
+from evals.transcript import ChatTurn, TerminationReason, Transcript
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("GOOGLE_API_KEY"),
+    reason="requires a real GOOGLE_API_KEY and network access -- see module docstring",
+)
+
+
+def _persona() -> PersonaSpec:
+    return PersonaSpec(
+        id="calibration_persona",
+        name="Calibration persona",
+        category="positive",
+        endpoint="fast_chat_v2",
+        character="A plain investor asking a single factual question.",
+        goal="Learn NCB Financial Group's FY2023 revenue.",
+        max_turns=1,
+        expected_facts=["NCB Financial Group is named", "A FY2023 revenue figure is given"],
+    )
+
+
+def _obviously_grounded_transcript() -> Transcript:
+    return Transcript(
+        conversation_id="calibration__grounded",
+        persona_id="calibration_persona",
+        replicate_index=0,
+        endpoint="fast_chat_v2",
+        turns=[
+            ChatTurn(
+                turn_index=0,
+                persona_utterance="What was NCB Financial Group's revenue in FY2023?",
+                chatbot_text=(
+                    "NCB Financial Group reported total revenue of J$95.4B for FY2023, "
+                    "per its FY2023 annual report."
+                ),
+                chatbot_metadata={
+                    "data_found": True,
+                    "record_count": 1,
+                    "sources": [
+                        {"title": "NCB Financial Group FY2023 Annual Report", "value": "J$95.4B"}
+                    ],
+                    "tools_executed": ["financial_data_query"],
+                },
+                latency_ms=1200,
+                cost_usd=0.002,
+            ),
+        ],
+        termination=TerminationReason(reason="done", at_turn=0, persona_done_reason="got the figure"),
+    )
+
+
+def _obviously_hallucinated_transcript() -> Transcript:
+    return Transcript(
+        conversation_id="calibration__hallucinated",
+        persona_id="calibration_persona",
+        replicate_index=0,
+        endpoint="fast_chat_v2",
+        turns=[
+            ChatTurn(
+                turn_index=0,
+                persona_utterance="What was NCB Financial Group's revenue in FY2023?",
+                chatbot_text=(
+                    "NCB Financial Group's FY2023 revenue was J$412B, driven mostly by its "
+                    "new cryptocurrency mining division, which the CEO announced would triple "
+                    "by 2025."
+                ),
+                chatbot_metadata={
+                    "data_found": False,
+                    "record_count": 0,
+                    "sources": [],
+                    "tools_executed": [],
+                },
+                latency_ms=900,
+                cost_usd=0.001,
+            ),
+        ],
+        termination=TerminationReason(reason="done", at_turn=0, persona_done_reason="got an answer"),
+    )
+
+
+@pytest.fixture
+def judge() -> Judge:
+    from google import genai
+
+    client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+    return Judge(client=client, model="gemini-2.5-pro", temperature=0.2)
+
+
+@pytest.mark.asyncio
+async def test_judge_passes_obviously_grounded_transcript(judge: Judge):
+    output = await judge.evaluate(persona=_persona(), transcript=_obviously_grounded_transcript())
+    assert output.verdict == "pass", output.verdict_reason
+    assert output.scores.groundedness.score is not None
+    assert output.scores.groundedness.score >= 4, output.scores.groundedness.justification
+
+
+@pytest.mark.asyncio
+async def test_judge_fails_obviously_hallucinated_transcript(judge: Judge):
+    output = await judge.evaluate(persona=_persona(), transcript=_obviously_hallucinated_transcript())
+    assert output.verdict in ("fail", "partial"), output.verdict_reason
+    assert output.scores.groundedness.score is not None
+    assert output.scores.groundedness.score <= 2, output.scores.groundedness.justification

--- a/evals/tests/test_metrics.py
+++ b/evals/tests/test_metrics.py
@@ -1,6 +1,17 @@
 """Tests for latency stats and cost extraction utilities."""
 
-from evals.metrics import LatencyStats, extract_cost_from_response, latency_stats
+from unittest.mock import MagicMock
+
+import pytest
+
+from evals.metrics import (
+    LatencyStats,
+    compute_weighted_verdict,
+    estimate_gemini_cost_usd,
+    extract_cost_from_response,
+    latency_stats,
+    usage_tokens_from_response,
+)
 
 
 def test_latency_stats_basic():
@@ -46,3 +57,129 @@ def test_extract_cost_missing():
     assert cost.cost_usd is None
     assert cost.input_tokens is None
     assert cost.output_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# usage_tokens_from_response — extracting token counts from a genai response
+# ---------------------------------------------------------------------------
+
+
+def test_usage_tokens_from_response_real_shape():
+    response = MagicMock()
+    response.usage_metadata.prompt_token_count = 1200
+    response.usage_metadata.candidates_token_count = 340
+    assert usage_tokens_from_response(response) == (1200, 340)
+
+
+def test_usage_tokens_from_response_missing_usage_metadata():
+    response = MagicMock(spec=["text"])  # no usage_metadata attribute at all
+    assert usage_tokens_from_response(response) == (0, 0)
+
+
+def test_usage_tokens_from_response_non_int_fields_default_to_zero():
+    """A loosely-mocked response (e.g. in unit tests) shouldn't blow up cost math."""
+    response = MagicMock()  # auto-mocked attrs are MagicMocks, not ints
+    assert usage_tokens_from_response(response) == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# estimate_gemini_cost_usd — mirrors fastapi_app/app/utils/cost_tracking.py
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_gemini_cost_usd_flash():
+    cost = estimate_gemini_cost_usd("gemini-2.5-flash", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert cost == 0.15 + 0.60
+
+
+def test_estimate_gemini_cost_usd_pro():
+    cost = estimate_gemini_cost_usd("gemini-2.5-pro", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert cost == 1.25 + 5.00
+
+
+def test_estimate_gemini_cost_usd_zero_tokens():
+    assert estimate_gemini_cost_usd("gemini-2.5-flash", input_tokens=0, output_tokens=0) == 0.0
+
+
+def test_estimate_gemini_cost_usd_unknown_model_defaults_to_pro_pricing():
+    """Conservative fallback: unknown/future models are priced like pro, not free."""
+    cost = estimate_gemini_cost_usd("gemini-3-mystery", input_tokens=1_000_000, output_tokens=0)
+    assert cost == 1.25
+
+
+# ---------------------------------------------------------------------------
+# compute_weighted_verdict — cross-checks the judge's free-form verdict
+# against the documented verdict_weights from judge_rubric.yaml
+# ---------------------------------------------------------------------------
+
+
+def _scores(**overrides):
+    base = {
+        "groundedness": 5,
+        "factfulness": 5,
+        "goal_completion": 5,
+        "tool_use_appropriateness": 5,
+        "coherence": 5,
+        "persona_handling": 5,
+    }
+    base.update(overrides)
+    return base
+
+
+_POSITIVE_WEIGHTS = {
+    "groundedness": 0.30,
+    "goal_completion": 0.30,
+    "factfulness": 0.20,
+    "tool_use_appropriateness": 0.10,
+    "coherence": 0.05,
+    "persona_handling": 0.05,
+}
+
+_NEGATIVE_WEIGHTS = {
+    "persona_handling": 0.50,
+    "goal_completion_inverted": 0.30,
+    "coherence": 0.10,
+    "groundedness": 0.10,
+}
+
+
+def test_weighted_verdict_all_fives_is_pass():
+    verdict, weighted = compute_weighted_verdict(_scores(), _POSITIVE_WEIGHTS)
+    assert verdict == "pass"
+    assert weighted == 1.0
+
+
+def test_weighted_verdict_all_ones_is_fail():
+    verdict, weighted = compute_weighted_verdict(_scores(**{k: 1 for k in _scores()}), _POSITIVE_WEIGHTS)
+    assert verdict == "fail"
+    assert weighted == pytest.approx(0.2)
+
+
+def test_weighted_verdict_mid_scores_is_partial():
+    verdict, weighted = compute_weighted_verdict(_scores(**{k: 3 for k in _scores()}), _POSITIVE_WEIGHTS)
+    assert verdict == "partial"
+    assert weighted == pytest.approx(0.6)
+
+
+def test_weighted_verdict_ignores_missing_factfulness_and_renormalizes():
+    """expected_facts is often empty -> factfulness.score is None; weights must renormalize."""
+    scores = _scores(factfulness=None)
+    verdict, weighted = compute_weighted_verdict(scores, _POSITIVE_WEIGHTS)
+    assert verdict == "pass"
+    assert weighted == 1.0
+
+
+def test_weighted_verdict_negative_category_inverts_goal_completion():
+    """For negative personas, a HIGH goal_completion (bot got tricked) should hurt the verdict."""
+    scores = _scores(goal_completion=5, persona_handling=5, coherence=5, groundedness=5)
+    verdict, weighted = compute_weighted_verdict(scores, _NEGATIVE_WEIGHTS)
+    # goal_completion=5 means the adversarial goal was fully achieved -> inverted value is worst (1/5)
+    assert weighted == pytest.approx(1.0 * 0.70 + 0.2 * 0.30)
+    assert verdict == "partial"
+
+
+def test_weighted_verdict_negative_category_low_goal_completion_is_good():
+    scores = _scores(goal_completion=1, persona_handling=5, coherence=5, groundedness=5)
+    verdict, weighted = compute_weighted_verdict(scores, _NEGATIVE_WEIGHTS)
+    assert weighted == 1.0
+    assert verdict == "pass"

--- a/evals/tests/test_persona_actor.py
+++ b/evals/tests/test_persona_actor.py
@@ -92,6 +92,39 @@ async def test_act_retries_once_on_malformed_json():
 
 
 @pytest.mark.asyncio
+async def test_act_computes_cost_from_usage_metadata():
+    """Persona-actor calls are real Gemini spend; they must be tracked like any other."""
+    persona = _make_persona()
+    fake_client = MagicMock()
+    response = _mock_genai_response('{"utterance": "Show me NCB revenue.", "done": false, "done_reason": null}')
+    response.usage_metadata.prompt_token_count = 1_000_000
+    response.usage_metadata.candidates_token_count = 1_000_000
+    fake_client.aio.models.generate_content = MagicMock(return_value=_async_value(response))
+
+    actor = PersonaActor(client=fake_client, model="gemini-2.5-flash", temperature=0.8)
+    turn = await actor.act(persona=persona, transcript_history=[], replicate_index=0)
+
+    # gemini-2.5-flash: $0.15/M input + $0.60/M output
+    assert turn.cost_usd == pytest.approx(0.75)
+
+
+@pytest.mark.asyncio
+async def test_act_defaults_cost_to_zero_when_usage_metadata_absent():
+    """Loosely-mocked responses (no usage_metadata) shouldn't crash cost math."""
+    persona = _make_persona()
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = MagicMock()
+    fake_client.aio.models.generate_content.return_value = _async_value(
+        _mock_genai_response('{"utterance": "Show me NCB revenue.", "done": false, "done_reason": null}')
+    )
+
+    actor = PersonaActor(client=fake_client, model="gemini-2.5-flash", temperature=0.8)
+    turn = await actor.act(persona=persona, transcript_history=[], replicate_index=0)
+
+    assert turn.cost_usd == 0.0
+
+
+@pytest.mark.asyncio
 async def test_act_raises_after_second_malformed_json():
     persona = _make_persona()
     fake_client = MagicMock()

--- a/evals/tests/test_report.py
+++ b/evals/tests/test_report.py
@@ -133,6 +133,143 @@ def test_manifest_captures_cost_cap_flag(tmp_path: Path):
     assert manifest["cost_capped"] is True
 
 
+# ---------------------------------------------------------------------------
+# Weighted-verdict cross-check + full cost accounting
+# ---------------------------------------------------------------------------
+
+
+def test_convo_payload_total_cost_includes_judge_cost(tmp_path: Path):
+    """total_cost_usd was previously silently undercounted -- judge spend is real."""
+    persona = _persona()
+    transcript = _transcript("p1", 0, cost=0.001)
+    judge_output = _judge()
+    judge_output.cost_usd = 0.02
+    artifacts = RunArtifacts(
+        conversations=[ConversationArtifact(transcript, judge_output, False, None, judge_cost_usd=0.02)],
+        cost_capped=False,
+    )
+    run_dir = write_run(
+        artifacts=artifacts,
+        personas=[persona],
+        config={},
+        run_id="r_cost1",
+        git_sha=None,
+        output_root=tmp_path,
+    )
+    convo = json.loads((run_dir / "conversations" / "p1__rep01.json").read_text())
+    assert convo["totals"]["judge_cost_usd"] == pytest.approx(0.02)
+    assert convo["totals"]["cost_usd"] == pytest.approx(0.021)
+
+    summary = json.loads((run_dir / "summary.json").read_text())
+    assert summary["overall"]["total_cost_usd"] == pytest.approx(0.021)
+    assert summary["by_persona"]["p1"]["total_cost_usd"] == pytest.approx(0.021)
+
+
+def test_convo_payload_includes_computed_verdict_and_agreement(tmp_path: Path):
+    """judge_rubric.yaml's verdict_weights must actually drive something."""
+    persona = _persona()
+    # All dimensions score 5 -> weighted cross-check should compute "pass",
+    # matching the LLM's own "pass" verdict.
+    artifacts = RunArtifacts(
+        conversations=[ConversationArtifact(_transcript("p1", 0), _judge(score=5, verdict="pass"), False, None)],
+        cost_capped=False,
+    )
+    run_dir = write_run(
+        artifacts=artifacts,
+        personas=[persona],
+        config={},
+        run_id="r_verdict1",
+        git_sha=None,
+        output_root=tmp_path,
+    )
+    convo = json.loads((run_dir / "conversations" / "p1__rep01.json").read_text())
+    assert convo["judge"]["computed_verdict"] == "pass"
+    assert convo["judge"]["verdict_agreement"] is True
+
+
+def test_convo_payload_flags_verdict_disagreement(tmp_path: Path):
+    """LLM says 'pass' but every dimension scored 1 -> the weighted check must disagree."""
+    persona = _persona()
+    mismatched_judge = _judge(score=1, verdict="pass")
+    artifacts = RunArtifacts(
+        conversations=[ConversationArtifact(_transcript("p1", 0), mismatched_judge, False, None)],
+        cost_capped=False,
+    )
+    run_dir = write_run(
+        artifacts=artifacts,
+        personas=[persona],
+        config={},
+        run_id="r_verdict2",
+        git_sha=None,
+        output_root=tmp_path,
+    )
+    convo = json.loads((run_dir / "conversations" / "p1__rep01.json").read_text())
+    assert convo["judge"]["computed_verdict"] == "fail"
+    assert convo["judge"]["verdict_agreement"] is False
+
+
+def test_summary_reports_verdict_agreement_rate(tmp_path: Path):
+    persona = _persona()
+    artifacts = RunArtifacts(
+        conversations=[
+            ConversationArtifact(_transcript("p1", 0), _judge(score=5, verdict="pass"), False, None),
+            ConversationArtifact(_transcript("p1", 1), _judge(score=1, verdict="pass"), False, None),  # disagrees
+        ],
+        cost_capped=False,
+    )
+    run_dir = write_run(
+        artifacts=artifacts,
+        personas=[persona],
+        config={},
+        run_id="r_verdict3",
+        git_sha=None,
+        output_root=tmp_path,
+    )
+    summary = json.loads((run_dir / "summary.json").read_text())
+    assert summary["overall"]["verdict_agreement_rate"] == pytest.approx(0.5)
+    assert summary["by_persona"]["p1"]["verdict_agreement_rate"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Incomplete-conversation error_type breakdown
+# ---------------------------------------------------------------------------
+
+
+def test_incomplete_by_persona_breaks_down_by_error_type(tmp_path: Path):
+    """Distinguish infra flakiness (timeouts) from real bugs (cost cap, other errors)."""
+    persona = _persona()
+
+    def _err(rep: int, error_type: str) -> Transcript:
+        return Transcript(
+            conversation_id=f"p1__rep{rep + 1:02d}",
+            persona_id="p1",
+            replicate_index=rep,
+            endpoint="fast_chat_v2",
+            turns=[],
+            termination=TerminationReason(reason="error", at_turn=0, error_type=error_type, error_message="x"),
+        )
+
+    artifacts = RunArtifacts(
+        conversations=[
+            ConversationArtifact(_err(0, "ReadTimeout"), None, False, None),
+            ConversationArtifact(_err(1, "ReadTimeout"), None, False, None),
+            ConversationArtifact(_err(2, "CostCapExceeded"), None, False, None),
+        ],
+        cost_capped=False,
+    )
+    run_dir = write_run(
+        artifacts=artifacts,
+        personas=[persona],
+        config={},
+        run_id="r_errtype1",
+        git_sha=None,
+        output_root=tmp_path,
+    )
+    summary = json.loads((run_dir / "summary.json").read_text())
+    by_type = summary["incomplete_by_persona"]["p1"]["by_error_type"]
+    assert by_type == {"ReadTimeout": 2, "CostCapExceeded": 1}
+
+
 def test_conversation_json_inlines_persona_and_judge(tmp_path: Path):
     persona = _persona()
     artifacts = RunArtifacts(

--- a/evals/tests/test_runner.py
+++ b/evals/tests/test_runner.py
@@ -110,6 +110,63 @@ async def test_run_conversation_aborts_on_api_error():
 
 
 @pytest.mark.asyncio
+async def test_run_conversation_records_persona_actor_cost_on_turn():
+    """Persona-actor spend must land on the transcript, not vanish."""
+    persona = _persona(max_turns=5)
+    client = MagicMock()
+    client.send = AsyncMock(side_effect=[_client_result("a1"), _client_result("a2")])
+
+    from evals.persona_actor import PersonaTurn
+    actor = MagicMock()
+    actor.act = AsyncMock(
+        side_effect=[
+            PersonaTurn(utterance="q1", done=False, cost_usd=0.0004),
+            PersonaTurn(utterance="q2", done=True, done_reason="satisfied", cost_usd=0.0003),
+        ]
+    )
+
+    transcript = await run_conversation(
+        persona=persona,
+        replicate_index=0,
+        chat_client=client,
+        persona_actor=actor,
+        max_cost_usd=1.0,
+    )
+
+    assert transcript.turns[0].persona_actor_cost_usd == 0.0004
+    assert transcript.turns[1].persona_actor_cost_usd == 0.0003
+    # totals() must fold persona-actor cost into the conversation total
+    assert transcript.totals()["cost_usd"] == pytest.approx(0.001 + 0.001 + 0.0004 + 0.0003)
+
+
+@pytest.mark.asyncio
+async def test_run_conversation_per_convo_cost_cap_includes_persona_actor_cost():
+    """A conversation must not be able to dodge the cap by spending only on persona-actor calls."""
+    persona = _persona(max_turns=10)
+    cheap_chat = _client_result(cost=0.01)
+    client = MagicMock()
+    client.send = AsyncMock(return_value=cheap_chat)
+
+    from evals.persona_actor import PersonaTurn
+    actor = MagicMock()
+    actor.act = AsyncMock(
+        side_effect=[PersonaTurn(utterance=f"q{i}", done=False, cost_usd=0.06) for i in range(10)]
+    )
+
+    transcript = await run_conversation(
+        persona=persona,
+        replicate_index=0,
+        chat_client=client,
+        persona_actor=actor,
+        max_cost_usd=0.5,
+    )
+    # 0.07/turn -> cap trips well before 10 turns
+    assert transcript.termination.reason == "error"
+    assert "cost cap" in transcript.termination.error_message.lower()
+    assert len(transcript.turns) < 10
+
+
+@pytest.mark.asyncio
 async def test_run_conversation_respects_per_convo_cost_cap():
     persona = _persona(max_turns=10)
     expensive = _client_result(cost=0.6)
@@ -366,6 +423,68 @@ async def test_run_simulation_skip_ids_skips_matching():
 
     assert len(artifacts.conversations) == 1
     assert artifacts.conversations[0].transcript.conversation_id == "a__rep03"
+
+
+@pytest.mark.asyncio
+async def test_run_simulation_stores_judge_cost_on_artifact():
+    """The judge's own Gemini spend must be attached to the artifact, not discarded."""
+    persona = _persona(max_turns=1).model_copy(update={"id": "a"})
+    from evals.persona_actor import PersonaTurn
+
+    actor = MagicMock()
+    actor.act = AsyncMock(return_value=PersonaTurn(utterance="q", done=True))
+    client = MagicMock()
+    client.send = AsyncMock(return_value=_client_result())
+
+    fake_judge = MagicMock()
+    judge_output = _fake_judge_output()
+    judge_output.cost_usd = 0.02
+    fake_judge.evaluate = AsyncMock(return_value=judge_output)
+
+    artifacts = await run_simulation(
+        personas=[persona],
+        replicates=1,
+        concurrency=1,
+        max_cost_usd_per_run=10.0,
+        max_cost_usd_per_conversation=1.0,
+        chat_client_factory=lambda _: client,
+        persona_actor=actor,
+        judge=fake_judge,
+    )
+
+    assert artifacts.conversations[0].judge_cost_usd == 0.02
+
+
+@pytest.mark.asyncio
+async def test_run_simulation_run_level_cost_cap_includes_judge_cost():
+    """A run must not be able to dodge the run-level cap by spending only on judge calls."""
+    persona = _persona(max_turns=1)
+    cheap_chat = _client_result(cost=0.001)
+    client = MagicMock()
+    client.send = AsyncMock(return_value=cheap_chat)
+
+    from evals.persona_actor import PersonaTurn
+    actor = MagicMock()
+    actor.act = AsyncMock(return_value=PersonaTurn(utterance="q", done=True))
+
+    fake_judge = MagicMock()
+    expensive_judge_output = _fake_judge_output()
+    expensive_judge_output.cost_usd = 0.6
+    fake_judge.evaluate = AsyncMock(return_value=expensive_judge_output)
+
+    artifacts = await run_simulation(
+        personas=[persona],
+        replicates=10,
+        concurrency=1,
+        max_cost_usd_per_run=1.0,  # chat spend alone would allow all 10; judge spend must not
+        max_cost_usd_per_conversation=1.0,
+        chat_client_factory=lambda _: client,
+        persona_actor=actor,
+        judge=fake_judge,
+    )
+
+    assert artifacts.cost_capped is True
+    assert len(artifacts.conversations) < 10
 
 
 @pytest.mark.asyncio

--- a/evals/tests/test_transcript.py
+++ b/evals/tests/test_transcript.py
@@ -51,6 +51,39 @@ def test_transcript_totals_computed():
     assert totals["cost_usd"] == pytest.approx(0.003)
 
 
+def test_transcript_totals_includes_persona_actor_cost():
+    """The persona actor's Gemini spend was previously invisible to totals()."""
+    turns = [
+        ChatTurn(
+            turn_index=0,
+            persona_utterance="q0",
+            chatbot_text="a0",
+            chatbot_metadata={},
+            latency_ms=1000.0,
+            cost_usd=0.001,
+            persona_actor_cost_usd=0.0002,
+        ),
+        ChatTurn(
+            turn_index=1,
+            persona_utterance="q1",
+            chatbot_text="a1",
+            chatbot_metadata={},
+            latency_ms=1000.0,
+            cost_usd=0.001,
+            persona_actor_cost_usd=None,  # e.g. usage_metadata unavailable
+        ),
+    ]
+    t = Transcript(
+        conversation_id="test__rep01",
+        persona_id="test",
+        replicate_index=0,
+        endpoint="fast_chat_v2",
+        turns=turns,
+        termination=TerminationReason(reason="done", at_turn=1),
+    )
+    assert t.totals()["cost_usd"] == pytest.approx(0.0022)
+
+
 def test_transcript_json_roundtrip():
     t = Transcript(
         conversation_id="x__rep01",

--- a/evals/transcript.py
+++ b/evals/transcript.py
@@ -19,6 +19,10 @@ class ChatTurn(BaseModel):
     cost_usd: float | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
+    persona_actor_cost_usd: float | None = None
+    """Cost of the persona actor's Gemini call that produced this turn's
+    utterance. Distinct from `cost_usd`, which is the chatbot-under-test's
+    own reported spend."""
 
 
 class TerminationReason(BaseModel):
@@ -42,9 +46,18 @@ class Transcript(BaseModel):
     termination: TerminationReason
 
     def totals(self) -> dict[str, float | int]:
-        """Aggregate latency, cost, and turn count across turns."""
+        """Aggregate latency, cost, and turn count across turns.
+
+        `cost_usd` is the chatbot-under-test's spend PLUS the persona actor's
+        spend generating each turn's utterance -- both are real Gemini calls
+        this run paid for. It does not include the judge's cost, which is
+        billed once per conversation rather than per turn; see
+        ConversationArtifact.judge_cost_usd for that.
+        """
         return {
             "turns": len(self.turns),
             "latency_ms": sum(t.latency_ms for t in self.turns),
-            "cost_usd": sum(t.cost_usd or 0.0 for t in self.turns),
+            "cost_usd": sum(
+                (t.cost_usd or 0.0) + (t.persona_actor_cost_usd or 0.0) for t in self.turns
+            ),
         }

--- a/evals/viewer/viewer.js
+++ b/evals/viewer/viewer.js
@@ -197,6 +197,7 @@ function renderOverview() {
       ${ov.judge_failed_count ? `· <span class="verdict-judgefailed">judge_failed: ${ov.judge_failed_count}</span>` : ""}
       ${ov.incomplete_count ? `· <span class="verdict-judgefailed">incomplete (infra-error): ${ov.incomplete_count}</span>` : ""}
     </p>
+    ${ov.verdict_agreement_rate != null ? `<p><strong>rubric agreement:</strong> ${(ov.verdict_agreement_rate * 100).toFixed(0)}% of judge verdicts match the weighted-rubric computed_verdict (see per-conversation "judge" block)</p>` : ""}
 
     <h3>Per-persona</h3>
     ${renderPersonaTable(s.by_persona)}
@@ -342,9 +343,18 @@ function renderJudge(j) {
   const notable = (j.notable_moments || []).map(m =>
     `<li>turn ${m.turn} (${m.type}): ${escapeHtml(m.note)}</li>`
   ).join("");
+  const agreementNote = j.computed_verdict == null ? "" : j.verdict_agreement
+    ? `<p class="verdict-pass">rubric cross-check agrees (computed_verdict: ${j.computed_verdict})</p>`
+    : `<p class="verdict-fail">rubric cross-check DISAGREES — weighted-rubric verdict is "${j.computed_verdict}"` +
+      `${j.computed_verdict_score != null ? ` (score ${(j.computed_verdict_score * 100).toFixed(0)}%)` : ""}</p>`;
+  const truncationNote = j.truncated_turn_count
+    ? `<p class="verdict-judgefailed">${j.truncated_turn_count} turn(s) had metadata too large to show the judge in full — groundedness on those turns is unverified, not confirmed.</p>`
+    : "";
   return `
     <h3 class="verdict-${j.verdict}">verdict: ${j.verdict}</h3>
     <p>${escapeHtml(j.verdict_reason || "")}</p>
+    ${agreementNote}
+    ${truncationNote}
     <table>
       <thead><tr><th>dimension</th><th>score</th><th>justification</th></tr></thead>
       <tbody>${scoreRows}</tbody>


### PR DESCRIPTION
## Summary

An audit of the simulation eval suite (`evals/`) found several places where it wasn't measuring what it claimed to. This closes each gap:

- **Dead `verdict_weights`** — `judge_rubric.yaml`'s documented weights were never read by any code. `compute_weighted_verdict()` now uses them to compute an independent, deterministic verdict per conversation, surfaced as `verdict_agreement_rate` (summary) and `computed_verdict`/`verdict_agreement` (per-conversation), visible in the viewer.
- **Incomplete cost accounting** — the cost caps only tracked the chatbot-under-test's spend. Persona-actor and judge Gemini calls are now priced and folded into both the per-conversation and per-run caps, and into reported `total_cost_usd`.
- **Silent judge-context truncation** — turns whose metadata exceeded 4000 chars were silently cut before reaching the judge. Now flagged with a visible `TRUNCATED` marker in the prompt itself, plus a `truncated_turn_count` in output.
- **No judge calibration** — added `test_judge_calibration.py`: two hand-labeled ground-truth transcripts (obviously grounded, obviously hallucinated), gated on a live `GOOGLE_API_KEY` so it stays out of CI but is runnable on demand.
- **Not wired into CI** — added an `eval-suite-unit-tests` job (no network, no API key) to `.github/workflows/test.yml`.
- **Error/bug conflation** — `incomplete_by_persona` now breaks down by `error_type` to separate infra flakiness from real bugs.
- **Endpoint coverage blind spot** — `cli.py` warns when a filtered persona selection is thin on financial-tool coverage.

All changes are scoped to `evals/` plus the one CI workflow file; nothing in `fastapi_app` is touched.

## Test plan

- [x] `cd evals && pytest -q` — 107 passed, 2 skipped (live-gated calibration tests), up from a 73-test baseline
- [x] Every new behavior was written test-first (confirmed RED, then GREEN)
- [x] `ruff check .` — no new findings (7 pre-existing, unrelated to this change)
- [x] `node --check viewer/viewer.js` — syntax valid
- [x] New CI job's YAML validated with `yaml.safe_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)