### PR TITLE
fix(evals): resolve Gemini API key via the same alias chain as the app

### DIFF
--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -1,8 +1,14 @@
 """Wrapper that loads fastapi_app/.env and invokes evals.cli.
 
 This avoids needing to leak env-var values onto the command line or
-into shell history. The chatbot's `.env` only defines `CHATBOT_API_KEY`,
-so we alias it to `GOOGLE_API_KEY` (which the eval suite expects).
+into shell history.
+
+The eval suite reads the Gemini key from `GOOGLE_API_KEY` (see
+`gemini_api_key_env` in evals/config/default.yaml). A chatbot `.env` may
+name that key any of several ways, so we resolve it using the same alias
+chain the app itself accepts (`fastapi_app/app/config.py`,
+`financial_utils.py`, `dspy_modules.py`) and export the winner as
+`GOOGLE_API_KEY`.
 """
 
 from __future__ import annotations
@@ -16,14 +22,27 @@ from dotenv import load_dotenv
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ENV_PATH = REPO_ROOT / "fastapi_app" / ".env"
 
+# Keep in sync with AliasChoices in fastapi_app/app/config.py.
+API_KEY_ALIASES = ("GOOGLE_API_KEY", "GEMINI_API_KEY", "CHATBOT_API_KEY")
+
 if not ENV_PATH.exists():
     print(f"ERROR: missing {ENV_PATH}", file=sys.stderr)
     sys.exit(2)
 
 load_dotenv(ENV_PATH)
 
-if "CHATBOT_API_KEY" in os.environ and not os.environ.get("GOOGLE_API_KEY"):
-    os.environ["GOOGLE_API_KEY"] = os.environ["CHATBOT_API_KEY"]
+if not os.environ.get("GOOGLE_API_KEY"):
+    for alias in API_KEY_ALIASES:
+        if os.environ.get(alias):
+            os.environ["GOOGLE_API_KEY"] = os.environ[alias]
+            break
+    else:
+        print(
+            "ERROR: no Gemini API key found. Set one of "
+            f"{', '.join(API_KEY_ALIASES)} in {ENV_PATH}.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
 from evals.cli import main  # noqa: E402
 


### PR DESCRIPTION
## Problem

`scripts/run_eval.py` fails on every run with a key that the app itself accepts fine:

```
ERROR: env var GOOGLE_API_KEY not set
```

The wrapper only aliased one spelling:

```python
if "CHATBOT_API_KEY" in os.environ and not os.environ.get("GOOGLE_API_KEY"):
    os.environ["GOOGLE_API_KEY"] = os.environ["CHATBOT_API_KEY"]
```

and its docstring asserted *"The chatbot's `.env` only defines `CHATBOT_API_KEY`"*. That is no longer true — the current `.env` defines **`GEMINI_API_KEY`**, with neither `CHATBOT_API_KEY` nor `GOOGLE_API_KEY` present. The alias never fires, `GOOGLE_API_KEY` stays unset, and `evals.cli` aborts.

The app is unaffected, which is why this hid for a while: **the rest of the codebase already accepts all three spellings.**

| Location | Handling |
|---|---|
| `fastapi_app/app/config.py:42` | `AliasChoices("GOOGLE_API_KEY", "GEMINI_API_KEY", "CHATBOT_API_KEY")` |
| `fastapi_app/app/financial_utils.py:143` | `GOOGLE_API_KEY or GEMINI_API_KEY or CHATBOT_API_KEY` |
| `fastapi_app/app/dspy_modules.py:60` | same three-way fallback |
| `scripts/run_eval.py` | **`CHATBOT_API_KEY` only** ← the outlier |

So the server starts normally while the eval suite is unrunnable.

## Fix

Adopt the existing convention rather than invent a new one — same three names, same precedence, with a pointer to keep it in sync with `config.py`.

Also replaces the downstream failure with an actionable one. Previously the error surfaced inside `evals.cli` naming a variable that appears nowhere in `.env`; now it names every accepted variable and the `.env` path.

## Verification

`--help` is not a valid check here — it succeeded even with the bug, because the failure happens after argument parsing. Instead I stubbed `evals.cli` so the real file's resolution logic runs with no API cost, cleared the three variables to simulate a clean shell, and ran both versions against the real `.env` from `scripts/`:

| Version | Result |
|---|---|
| `main` (before) | reaches `evals.cli.main()` with `GOOGLE_API_KEY` **unset** → this is the observed failure |
| this branch | `GOOGLE_API_KEY` resolved from `GEMINI_API_KEY` (len 53) |

The full 22-persona suite was then launched successfully against a local server using this alias logic, confirming it gets past the key check into real conversations.

## Note for reviewers

`fastapi_app/.env` is gitignored (`.gitignore:86`), so **CI cannot detect this class of drift** — the suite looks healthy in review and breaks only on a developer machine whose `.env` uses a different accepted spelling. Worth considering a startup assertion or a documented canonical key name as a follow-up; out of scope here.

No tests added — the wrapper is a thin `os.environ` shim that `sys.exit`s into `evals.cli`, and testing it meaningfully would mean restructuring it into an importable function. Happy to do that if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)