### PR TITLE
fix(financial): populate cost_summary in /fast_chat_v2 responses

### DIFF
--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -5,7 +5,7 @@ import time
 import uuid
 import asyncio
 from datetime import datetime, timezone
-from typing import Dict, Any
+from typing import Dict, Any, List
 from contextlib import asynccontextmanager
 
 from app.models import (
@@ -19,6 +19,8 @@ from app.models import (
     Source,
     FinancialDataFilters,
     FinancialDataRecord,
+    CostSummary,
+    PhaseCost,
 )
 from app.charting import generate_chart
 from app.document_registry import build_document_index, presign_document
@@ -33,6 +35,7 @@ from app.metadata_loader import load_metadata_from_s3
 from app.document_selector import auto_load_relevant_documents
 from app.financial_utils import FinancialDataManager
 from app.agent_v2 import AgentV2
+from app.utils.cost_tracking import CostResult
 from app.config import get_config
 from app.response_cache import ResponseCache, build_response_cache
 from app.interaction_log import InteractionLogger, build_interaction_logger
@@ -546,6 +549,34 @@ async def chat(
 # ---------------------------------------------------------------------------
 
 
+def _build_cost_summary(costs: List[CostResult]) -> CostSummary:
+    """Turn the per-call costs collected via cost_sink into a CostSummary.
+
+    Mirrors AgentV2._build_cost_summary (app/agent_v2.py) so /fast_chat_v2
+    reports cost the same way /chat/stream does.
+    """
+    phases = [
+        PhaseCost(
+            phase=c.phase,
+            model=c.model,
+            input_tokens=c.token_usage.input_tokens,
+            output_tokens=c.token_usage.output_tokens,
+            cached_tokens=c.token_usage.cached_tokens,
+            input_cost_usd=c.input_cost,
+            output_cost_usd=c.output_cost,
+            total_cost_usd=c.total_cost,
+        )
+        for c in costs
+    ]
+    return CostSummary(
+        total_input_tokens=sum(p.input_tokens for p in phases),
+        total_output_tokens=sum(p.output_tokens for p in phases),
+        total_cached_tokens=sum(p.cached_tokens for p in phases),
+        total_cost_usd=sum(p.total_cost_usd for p in phases),
+        phases=phases,
+    )
+
+
 @app.post("/fast_chat_v2", response_model=FinancialDataResponse)
 async def fast_chat_v2(
     request: FinancialDataRequest,
@@ -766,6 +797,7 @@ async def fast_chat_v2(
             suggestions=suggestions if suggestions else None,
             chart=chart_spec,
             sources=sources,
+            cost_summary=_build_cost_summary(request_costs),
         )
     except HTTPException as e:
         schedule_log(response=None, cache_hit=False, success=False, error_message=str(e.detail))

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -221,6 +221,10 @@ class FinancialDataResponse(BaseModel):
     sources: Optional[List[Source]] = Field(
         default=None, description="Provenance for the answer (dataset sources)"
     )
+    cost_summary: Optional["CostSummary"] = Field(
+        default=None,
+        description="Internal: Cost tracking summary for this request (developer/ops monitoring)",
+    )
 
 
 class JobStatus(str, Enum):

--- a/fastapi_app/tests/test_fast_chat_v2_cost_summary.py
+++ b/fastapi_app/tests/test_fast_chat_v2_cost_summary.py
@@ -1,0 +1,133 @@
+"""Regression test for issue #65: /fast_chat_v2 never returned cost_summary.
+
+FinancialDataResponse (the response model for /fast_chat_v2) had no
+cost_summary field at all, so the cost data the endpoint already computes
+(via cost_sink, logged to BigQuery) never made it into the HTTP response --
+unlike /chat/stream, whose AgentChatResponse does carry it. Confirmed by
+loadtest.py, which already assumes /fast_chat_v2 responses carry
+cost_summary (using its presence as the cache-hit/miss signal).
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models import FinancialDataFilters
+from app.utils.cost_tracking import CostResult, TokenUsage
+
+
+def _filters():
+    return FinancialDataFilters(
+        companies=["NCB Financial Group"],
+        years=["2023"],
+        standard_items=["net_profit"],
+        interpretation="NCB net profit for 2023",
+    )
+
+
+def _mock_financial_manager():
+    async def parse_user_query(query, conversation_history, last_query_data, cost_sink=None):
+        if cost_sink is not None:
+            cost_sink.append(
+                CostResult(
+                    input_cost=0.001,
+                    output_cost=0.002,
+                    total_cost=0.003,
+                    model="gemini-2.5-flash",
+                    phase="query_parsing",
+                    token_usage=TokenUsage(
+                        input_tokens=100, output_tokens=50, cached_tokens=0, total_tokens=150
+                    ),
+                )
+            )
+        return _filters()
+
+    async def format_response(
+        results,
+        query,
+        interpretation,
+        is_follow_up,
+        conversation_history,
+        unrecognized_items=None,
+        cost_sink=None,
+    ):
+        if cost_sink is not None:
+            cost_sink.append(
+                CostResult(
+                    input_cost=0.004,
+                    output_cost=0.005,
+                    total_cost=0.009,
+                    model="gemini-2.5-pro",
+                    phase="response_synthesis",
+                    token_usage=TokenUsage(
+                        input_tokens=200, output_tokens=80, cached_tokens=0, total_tokens=280
+                    ),
+                )
+            )
+        return "NCB net profit for 2023 was J$5B."
+
+    manager = Mock()
+    manager.parse_user_query = parse_user_query
+    manager.validate_data_availability = Mock(return_value={"warnings": [], "suggestions": []})
+    manager.query_data = Mock(return_value=[])
+    manager.format_response = format_response
+    manager.describe_source = Mock(return_value=None)
+    return manager
+
+
+def test_fast_chat_v2_populates_cost_summary_on_cache_miss(monkeypatch):
+    monkeypatch.setattr(app.state, "financial_manager", _mock_financial_manager(), raising=False)
+    monkeypatch.setattr(app.state, "response_cache", None, raising=False)
+    monkeypatch.setattr(app.state, "interaction_logger", None, raising=False)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/fast_chat_v2",
+        json={
+            "query": "What was NCB net profit for 2023?",
+            "conversation_history": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert resp.status_code == 200
+    cost_summary = resp.json()["cost_summary"]
+    assert cost_summary is not None
+    assert cost_summary["total_input_tokens"] == 300
+    assert cost_summary["total_output_tokens"] == 130
+    assert cost_summary["total_cost_usd"] == pytest.approx(0.012)
+    phases = cost_summary["phases"]
+    assert [p["phase"] for p in phases] == ["query_parsing", "response_synthesis"]
+
+
+def test_fast_chat_v2_cache_hit_has_no_cost_summary(monkeypatch):
+    class FakeCache:
+        async def get(self, key):
+            return {
+                "response": "cached answer",
+                "data_found": True,
+                "record_count": 0,
+                "filters_used": _filters().model_dump(),
+                "data_preview": None,
+                "chart": None,
+                "sources": None,
+                "warnings": None,
+                "suggestions": None,
+            }
+
+        async def set(self, key, value):
+            raise AssertionError("set() should not be called on a cache hit")
+
+    monkeypatch.setattr(app.state, "financial_manager", _mock_financial_manager(), raising=False)
+    monkeypatch.setattr(app.state, "response_cache", FakeCache(), raising=False)
+    monkeypatch.setattr(app.state, "interaction_logger", None, raising=False)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/fast_chat_v2",
+        json={"query": "What was NCB net profit for 2023?", "conversation_history": []},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["cost_summary"] is None


### PR DESCRIPTION
## Summary
- `FinancialDataResponse` (the response model for `/fast_chat_v2`) never had a `cost_summary` field, so the per-call Gemini costs the endpoint already computes and logs to BigQuery via `cost_sink`/`request_costs` never made it into the HTTP response — unlike `/chat/stream`'s `AgentChatResponse`, which does carry it.
- Added `cost_summary: Optional[CostSummary]` to `FinancialDataResponse` and a `_build_cost_summary()` helper (mirroring `AgentV2._build_cost_summary`) that turns `request_costs` into a `CostSummary` on cache misses. Cache hits still return `cost_summary=None` (no Gemini calls were made), which matches `loadtest.py`'s existing assumption that a cache hit is signaled by a missing `cost_summary`.
- This also explains the silent zeros the eval suite (`evals/metrics.py`) was reporting for `fast_chat_v2` cost totals.

Fixes #65

## Test plan
- [x] New `fastapi_app/tests/test_fast_chat_v2_cost_summary.py`: cache-miss populates `cost_summary` with correct token/cost totals and phase breakdown; cache-hit returns `cost_summary: None`. Verified the cache-miss test fails without the fix.
- [x] `pytest tests/test_fast_chat_v2_cost_summary.py tests/test_chat_stream_endpoint.py tests/unit/` — 147 passed
- [x] `ruff check` on changed files — clean
- [x] `mypy` on changed files — no new errors vs. baseline
- [x] Full suite run confirmed no regressions (pre-existing, unrelated failures — BigQuery credential mocking, `aioboto3` — are identical with and without this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)