### PR TITLE
fix(agent): stop thinking tokens truncating refusals, and record how generation ended

### DIFF
--- a/fastapi_app/app/agent_v2.py
+++ b/fastapi_app/app/agent_v2.py
@@ -13,6 +13,7 @@ Architecture:
 """
 
 import asyncio
+import os
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -80,7 +81,52 @@ SYSTEM_PROMPT_NO_SEARCH = SYSTEM_PROMPT.replace(
 )
 
 # Model used for the cheap route + refusal calls (Phase A).
-ROUTER_MODEL = "gemini-2.5-flash"
+# Router/refusal calls run on a small output budget, so the model must not spend
+# that budget thinking. Gemini 2.5 honours thinking_budget=0; Gemini 3.x ignores
+# it (it uses thinking_level, whose lowest supported value still spends ~250
+# tokens), which is why the router stays pinned to 2.5 for now. Issue #72 has
+# the measurements behind this.
+DEFAULT_ROUTER_MODEL = "gemini-2.5-flash"
+
+# Budget shared between thinking and visible output on the refusal call. The
+# original 256 was exhausted by thinking alone, truncating the answer mid-word.
+REFUSAL_MAX_OUTPUT_TOKENS = 1024
+ROUTER_MAX_OUTPUT_TOKENS = 256
+
+# Thinking disabled outright: the router emits one word and a refusal is one or
+# two sentences. Neither needs deliberation, and both paid for it in truncations.
+NO_THINKING = types.ThinkingConfig(thinking_budget=0)
+
+
+def resolve_router_model() -> str:
+    """Router model, overridable per environment for trialling a candidate.
+
+    Set ROUTER_MODEL_NAME to pin a different model without a code change. Any
+    replacement must support disabling thinking, or it will reintroduce the
+    truncation this guards against.
+    """
+    return os.getenv("ROUTER_MODEL_NAME", "").strip() or DEFAULT_ROUTER_MODEL
+
+
+def extract_finish_reason(response: Any) -> Optional[str]:
+    """Bare finish-reason name from a Gemini response, or None if unavailable.
+
+    The SDK yields an enum whose str() is 'FinishReason.MAX_TOKENS', so prefer
+    .name. Never raises: this feeds logging, which must not break a request.
+    """
+    try:
+        candidates = getattr(response, "candidates", None) or []
+        if not candidates:
+            return None
+        reason = getattr(candidates[0], "finish_reason", None)
+        if reason is None:
+            return None
+        return getattr(reason, "name", None) or str(reason).rsplit(".", 1)[-1]
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+ROUTER_MODEL = resolve_router_model()
 
 # Phase-A step 1 — ROUTE: a plain-text 2-way classifier (no tools, no grounding).
 # Every query answers via Gemini 2.5 Pro + Google Search grounding; the router's
@@ -142,6 +188,7 @@ class AgentV2:
         self.client = get_genai_client()
         self.model_name = model_name
         self._phase_costs: List[PhaseCost] = []
+        self._finish_reason: Optional[str] = None
 
     # --------------------------------------------------------------------------
     # Cost Tracking
@@ -150,6 +197,7 @@ class AgentV2:
     def _reset_cost_tracking(self) -> None:
         """Reset cost tracking for a new request."""
         self._phase_costs = []
+        self._finish_reason = None
 
     def _add_phase_cost(
         self,
@@ -161,6 +209,7 @@ class AgentV2:
         input_cost: float,
         output_cost: float,
         total_cost: float,
+        thinking_tokens: int = 0,
     ) -> None:
         """Add a phase cost to tracking."""
         self._phase_costs.append(
@@ -170,6 +219,7 @@ class AgentV2:
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 cached_tokens=cached_tokens,
+                thinking_tokens=thinking_tokens,
                 input_cost_usd=input_cost,
                 output_cost_usd=output_cost,
                 total_cost_usd=total_cost,
@@ -182,6 +232,7 @@ class AgentV2:
             total_input_tokens=sum(p.input_tokens for p in self._phase_costs),
             total_output_tokens=sum(p.output_tokens for p in self._phase_costs),
             total_cached_tokens=sum(p.cached_tokens for p in self._phase_costs),
+            total_thinking_tokens=sum(p.thinking_tokens for p in self._phase_costs),
             total_cost_usd=sum(p.total_cost_usd for p in self._phase_costs),
             phases=self._phase_costs.copy(),
         )
@@ -218,6 +269,7 @@ class AgentV2:
             input_cost=cost.input_cost,
             output_cost=cost.output_cost,
             total_cost=cost.total_cost,
+            thinking_tokens=cost.token_usage.thinking_tokens,
         )
 
     # --------------------------------------------------------------------------
@@ -433,7 +485,8 @@ class AgentV2:
                 config=types.GenerateContentConfig(
                     system_instruction=QUERY_ROUTER_PROMPT,
                     temperature=0.0,
-                    max_output_tokens=256,
+                    max_output_tokens=ROUTER_MAX_OUTPUT_TOKENS,
+                    thinking_config=NO_THINKING,
                 ),
             )
             self._track_cost(route, "routing", model=ROUTER_MODEL)
@@ -454,11 +507,13 @@ class AgentV2:
                 config=types.GenerateContentConfig(
                     system_instruction=REFUSAL_FLASH_PROMPT,
                     temperature=0.1,
-                    max_output_tokens=256,
+                    max_output_tokens=REFUSAL_MAX_OUTPUT_TOKENS,
+                    thinking_config=NO_THINKING,
                     tools=None,
                 ),
             )
             self._track_cost(refusal, "refusal", model=ROUTER_MODEL)
+            self._finish_reason = extract_finish_reason(refusal)
 
             response_text = (refusal.text or "").strip() or (
                 "I can only assist with JSE and Jamaican financial topics. "
@@ -486,6 +541,7 @@ class AgentV2:
                 "suggestions": None,
                 "conversation_history": updated_history,
                 "warnings": None,
+                "finish_reason": self._finish_reason,
                 "cost_summary": self._build_cost_summary(),
             }
 
@@ -572,6 +628,7 @@ class AgentV2:
 
             # Track cost
             self._track_cost(response, "generation")
+            self._finish_reason = extract_finish_reason(response)
 
             # Extract response text
             response_text = response.text if response.text else ""
@@ -613,6 +670,7 @@ class AgentV2:
                 "suggestions": None,  # Could be extracted from response if needed
                 "conversation_history": updated_history,
                 "warnings": None,
+                "finish_reason": self._finish_reason,
                 "cost_summary": self._build_cost_summary(),
             }
 
@@ -641,5 +699,6 @@ class AgentV2:
                 "suggestions": None,
                 "conversation_history": updated_history[-20:],
                 "warnings": [f"Error: {str(e)}"],
+                "finish_reason": self._finish_reason,
                 "cost_summary": self._build_cost_summary(),
             }

--- a/fastapi_app/app/interaction_log.py
+++ b/fastapi_app/app/interaction_log.py
@@ -40,6 +40,7 @@ INTERACTIONS_SCHEMA = [
     bigquery.SchemaField("input_tokens", "INTEGER", mode="NULLABLE"),
     bigquery.SchemaField("output_tokens", "INTEGER", mode="NULLABLE"),
     bigquery.SchemaField("total_tokens", "INTEGER", mode="NULLABLE"),
+    bigquery.SchemaField("thinking_tokens", "INTEGER", mode="NULLABLE"),
     bigquery.SchemaField("cost_usd", "FLOAT", mode="NULLABLE"),
     bigquery.SchemaField("phase_costs_json", "STRING", mode="NULLABLE"),
     bigquery.SchemaField("latency_ms", "FLOAT", mode="NULLABLE"),
@@ -48,6 +49,10 @@ INTERACTIONS_SCHEMA = [
     bigquery.SchemaField("record_count", "INTEGER", mode="NULLABLE"),
     bigquery.SchemaField("success", "BOOLEAN", mode="REQUIRED"),
     bigquery.SchemaField("error_message", "STRING", mode="NULLABLE"),
+    # How generation actually ended. `success` only reports whether the request
+    # threw, so a MAX_TOKENS stop reads as a clean success without these.
+    bigquery.SchemaField("finish_reason", "STRING", mode="NULLABLE"),
+    bigquery.SchemaField("truncated", "BOOLEAN", mode="NULLABLE"),
     # Provenance returned to the caller. `source_count` is denormalised on
     # purpose: "what share of answers cited nothing" is the grounding-failure
     # signal, and it should not require an UNNEST to ask.
@@ -137,6 +142,9 @@ class InteractionLogger:
         model: Optional[str] = None,
         input_tokens: int = 0,
         output_tokens: int = 0,
+        thinking_tokens: Optional[int] = None,
+        total_tokens: Optional[int] = None,
+        finish_reason: Optional[str] = None,
         cost_usd: float = 0.0,
         phase_costs: Optional[Any] = None,
         latency_ms: Optional[float] = None,
@@ -166,7 +174,18 @@ class InteractionLogger:
             "model": model,
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
-            "total_tokens": (input_tokens or 0) + (output_tokens or 0),
+            "thinking_tokens": thinking_tokens,
+            # Prefer the total the API reported: it includes thinking tokens,
+            # which input + output alone silently drops (issue #72).
+            "total_tokens": (
+                total_tokens
+                if total_tokens is not None
+                else (input_tokens or 0) + (output_tokens or 0)
+            ),
+            "finish_reason": finish_reason,
+            # None means "the model did not tell us", which is not the same as
+            # "not truncated" — keep the three states distinguishable.
+            "truncated": (finish_reason == "MAX_TOKENS" if finish_reason else None),
             "cost_usd": cost_usd,
             "phase_costs_json": json.dumps(phase_costs, default=str) if phase_costs else None,
             "latency_ms": latency_ms,

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1073,6 +1073,7 @@ async def chat_stream(
             )
 
         cost_summary = response.cost_summary
+        thinking_tokens = cost_summary.total_thinking_tokens if cost_summary else None
         schedule_log(
             response=response.response,
             cache_hit=False,
@@ -1081,6 +1082,17 @@ async def chat_stream(
             record_count=response.record_count,
             input_tokens=cost_summary.total_input_tokens if cost_summary else 0,
             output_tokens=cost_summary.total_output_tokens if cost_summary else 0,
+            thinking_tokens=thinking_tokens,
+            # Thinking is billed as output but reported separately, so the real
+            # total is input + visible output + thinking (issue #72).
+            total_tokens=(
+                cost_summary.total_input_tokens
+                + cost_summary.total_output_tokens
+                + cost_summary.total_thinking_tokens
+                if cost_summary
+                else None
+            ),
+            finish_reason=result.get("finish_reason"),
             cost_usd=cost_summary.total_cost_usd if cost_summary else 0.0,
             phase_costs=[p.phase for p in cost_summary.phases] if cost_summary else None,
             sources=response.sources,

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -358,6 +358,9 @@ class PhaseCost(BaseModel):
     input_tokens: int = Field(default=0, description="Number of input tokens")
     output_tokens: int = Field(default=0, description="Number of output tokens")
     cached_tokens: int = Field(default=0, description="Number of cached tokens")
+    thinking_tokens: int = Field(
+        default=0, description="Reasoning tokens, billed as output and counted against the cap"
+    )
     input_cost_usd: float = Field(default=0.0, description="Cost for input tokens in USD")
     output_cost_usd: float = Field(default=0.0, description="Cost for output tokens in USD")
     total_cost_usd: float = Field(default=0.0, description="Total cost for this phase in USD")
@@ -374,6 +377,9 @@ class CostSummary(BaseModel):
     total_input_tokens: int = Field(default=0, description="Total input tokens across all phases")
     total_output_tokens: int = Field(default=0, description="Total output tokens across all phases")
     total_cached_tokens: int = Field(default=0, description="Total cached tokens across all phases")
+    total_thinking_tokens: int = Field(
+        default=0, description="Total reasoning tokens across all phases"
+    )
     total_cost_usd: float = Field(default=0.0, description="Total cost in USD across all phases")
     phases: List[PhaseCost] = Field(default_factory=list, description="Cost breakdown by phase")
 

--- a/fastapi_app/app/utils/cost_tracking.py
+++ b/fastapi_app/app/utils/cost_tracking.py
@@ -87,6 +87,10 @@ class TokenUsage:
     output_tokens: int = 0
     cached_tokens: int = 0
     total_tokens: int = 0
+    # Billed as output and counted against max_output_tokens, but reported
+    # separately from candidates_token_count — so a call can exhaust its budget
+    # on thinking and return almost no visible text (issue #72).
+    thinking_tokens: int = 0
 
     @classmethod
     def from_response(cls, response: Any) -> "TokenUsage":
@@ -107,12 +111,14 @@ class TokenUsage:
         output_tokens = getattr(metadata, "candidates_token_count", 0) or 0
         cached_tokens = getattr(metadata, "cached_content_token_count", 0) or 0
         total_tokens = getattr(metadata, "total_token_count", 0) or 0
+        thinking_tokens = getattr(metadata, "thoughts_token_count", 0) or 0
 
         return cls(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cached_tokens=cached_tokens,
             total_tokens=total_tokens or (input_tokens + output_tokens),
+            thinking_tokens=thinking_tokens,
         )
 
 

--- a/fastapi_app/tests/test_agent_v2_truncation.py
+++ b/fastapi_app/tests/test_agent_v2_truncation.py
@@ -1,0 +1,212 @@
+"""Tests for silent-truncation visibility and thinking-budget control on AgentV2.
+
+Background (issue #72): prod answers were breaking off mid-word while being
+recorded as `success = true`. Reproducing the refusal call against the live API
+showed `finish_reason = MAX_TOKENS` with 217-248 *thinking* tokens consuming a
+256-token `max_output_tokens` budget, leaving 4-11 visible tokens.
+
+Two things had to be true for that to reach a user unnoticed:
+  1. Nothing read `finish_reason` off the response, so an abnormal stop was
+     indistinguishable from a normal one.
+  2. Thinking was left at the model default on calls with a tight output cap.
+
+These tests pin both behaviours.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agent_v2 import AgentV2, extract_finish_reason, resolve_router_model
+
+
+@pytest.fixture
+def mock_genai_client():
+    with patch("app.agent_v2.get_genai_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content = AsyncMock()
+        mock_get_client.return_value = mock_client
+        yield mock_client
+
+
+def _route_response(decision="ALLOW"):
+    resp = MagicMock()
+    resp.text = decision
+    resp.candidates = []
+    resp.usage_metadata = None
+    return resp
+
+
+def _text_response(text, finish_reason=None):
+    """A generation response, optionally carrying a finish_reason on candidate 0."""
+    resp = MagicMock()
+    resp.text = text
+    resp.usage_metadata = None
+    if finish_reason is None:
+        resp.candidates = []
+    else:
+        candidate = MagicMock()
+        candidate.finish_reason = finish_reason
+        resp.candidates = [candidate]
+    return resp
+
+
+class _FinishReasonEnum:
+    """Stands in for the SDK's FinishReason enum, whose str() is prefixed."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return f"FinishReason.{self.name}"
+
+
+# ---------------------------------------------------------------------------
+# extract_finish_reason
+# ---------------------------------------------------------------------------
+
+
+def test_extract_finish_reason_unwraps_sdk_enum():
+    """The SDK yields an enum whose str() is 'FinishReason.MAX_TOKENS' — we want the bare name."""
+    resp = _text_response("truncated text", finish_reason=_FinishReasonEnum("MAX_TOKENS"))
+    assert extract_finish_reason(resp) == "MAX_TOKENS"
+
+
+def test_extract_finish_reason_accepts_plain_string():
+    resp = _text_response("done", finish_reason="STOP")
+    assert extract_finish_reason(resp) == "STOP"
+
+
+def test_extract_finish_reason_none_when_no_candidates():
+    assert extract_finish_reason(_text_response("done")) is None
+
+
+def test_extract_finish_reason_none_on_garbage():
+    """A malformed response must not raise — logging is never allowed to break a request."""
+    assert extract_finish_reason(None) is None
+    assert extract_finish_reason(object()) is None
+
+
+# ---------------------------------------------------------------------------
+# Thinking budget — the actual fix for issue #72
+# ---------------------------------------------------------------------------
+
+
+def test_router_call_disables_thinking(mock_genai_client):
+    """The router only emits one word; thinking must not eat its 256-token budget."""
+    mock_genai_client.aio.models.generate_content.side_effect = [
+        _route_response("REFUSE"),
+        _text_response("JSE topics only."),
+    ]
+    asyncio.run(AgentV2().run(query="What is bitcoin?"))
+
+    route_cfg = mock_genai_client.aio.models.generate_content.call_args_list[0].kwargs["config"]
+    assert route_cfg.thinking_config is not None
+    assert route_cfg.thinking_config.thinking_budget == 0
+
+
+def test_refusal_call_disables_thinking(mock_genai_client):
+    """The refusal call is where prod truncated: thinking consumed the whole cap."""
+    mock_genai_client.aio.models.generate_content.side_effect = [
+        _route_response("REFUSE"),
+        _text_response("JSE topics only."),
+    ]
+    asyncio.run(AgentV2().run(query="Should I buy Tesla?"))
+
+    refusal_cfg = mock_genai_client.aio.models.generate_content.call_args_list[1].kwargs["config"]
+    assert refusal_cfg.thinking_config is not None
+    assert refusal_cfg.thinking_config.thinking_budget == 0
+
+
+def test_refusal_output_cap_leaves_headroom(mock_genai_client):
+    """256 left no margin. A refusal is 1-2 sentences; the cap should not be the binding limit."""
+    mock_genai_client.aio.models.generate_content.side_effect = [
+        _route_response("REFUSE"),
+        _text_response("JSE topics only."),
+    ]
+    asyncio.run(AgentV2().run(query="Should I buy Tesla?"))
+
+    refusal_cfg = mock_genai_client.aio.models.generate_content.call_args_list[1].kwargs["config"]
+    assert refusal_cfg.max_output_tokens >= 512
+
+
+# ---------------------------------------------------------------------------
+# finish_reason propagation
+# ---------------------------------------------------------------------------
+
+
+def test_refuse_path_surfaces_finish_reason(mock_genai_client):
+    mock_genai_client.aio.models.generate_content.side_effect = [
+        _route_response("REFUSE"),
+        _text_response(
+            "As a financial analyst, I cannot",
+            finish_reason=_FinishReasonEnum("MAX_TOKENS"),
+        ),
+    ]
+    result = asyncio.run(AgentV2().run(query="top 3 stocks to buy today"))
+    assert result["finish_reason"] == "MAX_TOKENS"
+
+
+def test_refuse_path_surfaces_normal_stop(mock_genai_client):
+    mock_genai_client.aio.models.generate_content.side_effect = [
+        _route_response("REFUSE"),
+        _text_response("JSE topics only.", finish_reason=_FinishReasonEnum("STOP")),
+    ]
+    result = asyncio.run(AgentV2().run(query="What is bitcoin?"))
+    assert result["finish_reason"] == "STOP"
+
+
+def test_web_path_surfaces_finish_reason(mock_genai_client):
+    """Truncation is not unique to the refusal path — the synthesis path reports too."""
+    mock_genai_client.aio.models.generate_content.side_effect = [
+        _route_response("ALLOW"),
+        _text_response("GraceKennedy reported", finish_reason=_FinishReasonEnum("MAX_TOKENS")),
+    ]
+    result = asyncio.run(AgentV2().run(query="GraceKennedy revenue 2024", enable_web_search=True))
+    assert result["finish_reason"] == "MAX_TOKENS"
+
+
+def test_error_path_finish_reason_is_none(mock_genai_client):
+    """A thrown request has no generation outcome to report."""
+    mock_genai_client.aio.models.generate_content.side_effect = RuntimeError("boom")
+    result = asyncio.run(AgentV2().run(query="anything"))
+    assert result["finish_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# Router model pinning
+# ---------------------------------------------------------------------------
+
+
+def test_router_model_defaults_to_pinned_flash(monkeypatch):
+    monkeypatch.delenv("ROUTER_MODEL_NAME", raising=False)
+    assert resolve_router_model() == "gemini-2.5-flash"
+
+
+def test_router_model_overridable_by_env(monkeypatch):
+    """Lets a candidate model be trialled in one environment without a code change."""
+    monkeypatch.setenv("ROUTER_MODEL_NAME", "gemini-3.7-flash")
+    assert resolve_router_model() == "gemini-3.7-flash"
+
+
+def test_router_model_blank_env_falls_back(monkeypatch):
+    monkeypatch.setenv("ROUTER_MODEL_NAME", "   ")
+    assert resolve_router_model() == "gemini-2.5-flash"
+
+
+def test_cost_summary_totals_thinking_tokens(mock_genai_client):
+    """Thinking is billed as output; the summary must expose it for logging."""
+    route = _route_response("REFUSE")
+    refusal = _text_response("JSE topics only.", finish_reason=_FinishReasonEnum("STOP"))
+    for resp, thinking in ((route, 0), (refusal, 243)):
+        resp.usage_metadata = MagicMock()
+        resp.usage_metadata.prompt_token_count = 100
+        resp.usage_metadata.candidates_token_count = 10
+        resp.usage_metadata.cached_content_token_count = 0
+        resp.usage_metadata.total_token_count = 110 + thinking
+        resp.usage_metadata.thoughts_token_count = thinking
+
+    mock_genai_client.aio.models.generate_content.side_effect = [route, refusal]
+    result = asyncio.run(AgentV2().run(query="Should I buy Tesla?"))
+    assert result["cost_summary"].total_thinking_tokens == 243

--- a/fastapi_app/tests/test_chat_stream_endpoint.py
+++ b/fastapi_app/tests/test_chat_stream_endpoint.py
@@ -79,3 +79,59 @@ def test_chat_stream_accepts_but_ignores_legacy_enable_financial_data():
     assert resp.status_code == 200
     run_kwargs = instance.run.call_args.kwargs
     assert "enable_financial_data" not in run_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Generation-outcome logging (issue #72)
+# ---------------------------------------------------------------------------
+
+
+def _log_spy_call(agent_result):
+    """Drive /chat/stream with a stub agent and return build_row's kwargs."""
+    from unittest.mock import MagicMock
+
+    from app.interaction_log import InteractionLogger
+    from app.main import app, get_interaction_logger_dep
+
+    fake_logger = MagicMock()
+    fake_logger.log = AsyncMock()
+    app.dependency_overrides[get_interaction_logger_dep] = lambda: fake_logger
+    try:
+        with (
+            patch("app.main.AgentV2") as MockAgent,
+            patch.object(InteractionLogger, "build_row", wraps=InteractionLogger.build_row) as spy,
+        ):
+            MockAgent.return_value.run = AsyncMock(return_value=agent_result)
+            resp = TestClient(app).post("/chat/stream", json={"query": "top 3 stocks to buy"})
+        assert resp.status_code == 200
+        return spy.call_args.kwargs
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_chat_stream_logs_finish_reason():
+    result = _result()
+    result["finish_reason"] = "MAX_TOKENS"
+    assert _log_spy_call(result)["finish_reason"] == "MAX_TOKENS"
+
+
+def test_chat_stream_logs_none_finish_reason_when_absent():
+    """A cache hit or an older agent result carries no outcome — stay null, not False."""
+    assert _log_spy_call(_result())["finish_reason"] is None
+
+
+def test_chat_stream_logs_thinking_tokens_from_cost_summary():
+    from app.models import CostSummary, PhaseCost
+
+    result = _result()
+    result["finish_reason"] = "MAX_TOKENS"
+    result["cost_summary"] = CostSummary(
+        total_input_tokens=392,
+        total_output_tokens=9,
+        total_thinking_tokens=243,
+        total_cost_usd=0.0001,
+        phases=[PhaseCost(phase="refusal", model="gemini-2.5-flash")],
+    )
+    kwargs = _log_spy_call(result)
+    assert kwargs["thinking_tokens"] == 243
+    assert kwargs["total_tokens"] == 392 + 9 + 243

--- a/fastapi_app/tests/unit/test_cost_tracking.py
+++ b/fastapi_app/tests/unit/test_cost_tracking.py
@@ -274,3 +274,25 @@ class TestCostTrackingConfig:
         assert config.gemini_flash_output_price == DEFAULT_FLASH_OUTPUT_PRICE
         assert config.gemini_pro_input_price == DEFAULT_PRO_INPUT_PRICE
         assert config.gemini_pro_output_price == DEFAULT_PRO_OUTPUT_PRICE
+
+
+@pytest.mark.unit
+class TestThinkingTokens:
+    """Thinking tokens are billed as output and count against max_output_tokens,
+    but nothing read them — see issue #72."""
+
+    def test_from_response_captures_thinking_tokens(self):
+        resp = Mock()
+        resp.usage_metadata = Mock()
+        resp.usage_metadata.prompt_token_count = 392
+        resp.usage_metadata.candidates_token_count = 9
+        resp.usage_metadata.cached_content_token_count = 0
+        resp.usage_metadata.total_token_count = 644
+        resp.usage_metadata.thoughts_token_count = 243
+
+        usage = TokenUsage.from_response(resp)
+        assert usage.thinking_tokens == 243
+        assert usage.total_tokens == 644
+
+    def test_thinking_tokens_default_zero_when_absent(self):
+        assert TokenUsage().thinking_tokens == 0

--- a/fastapi_app/tests/unit/test_interaction_log.py
+++ b/fastapi_app/tests/unit/test_interaction_log.py
@@ -204,3 +204,58 @@ def test_build_row_keys_match_declared_schema():
     produced = set(_row(sources=[]).keys())
     # `environment` is stamped in log(), not build_row()
     assert produced == declared - {"environment"}
+
+
+# ---------------------------------------------------------------------------
+# Generation-outcome columns (issue #72)
+#
+# finish_reason / truncated / thinking_tokens exist in INTERACTIONS_SCHEMA but
+# nothing wrote them, so a MAX_TOKENS stop was indistinguishable from a clean
+# one in BigQuery. total_tokens was recomputed as input + output, which also
+# discarded the thinking spend that caused the truncation.
+# ---------------------------------------------------------------------------
+
+
+def _row(**kwargs):
+    base = {
+        "endpoint": "chat_stream",
+        "query": "best performing stock for 2026",
+        "response": "As a financial analyst, I cannot",
+        "timestamp": "2026-08-24T17:07:56Z",
+    }
+    base.update(kwargs)
+    return InteractionLogger.build_row(**base)
+
+
+def test_build_row_records_finish_reason():
+    assert _row(finish_reason="MAX_TOKENS")["finish_reason"] == "MAX_TOKENS"
+
+
+def test_build_row_marks_max_tokens_as_truncated():
+    assert _row(finish_reason="MAX_TOKENS")["truncated"] is True
+
+
+def test_build_row_marks_normal_stop_as_not_truncated():
+    assert _row(finish_reason="STOP")["truncated"] is False
+
+
+def test_build_row_truncated_is_none_when_finish_reason_unknown():
+    """Null must keep meaning 'unknown', never 'not truncated'."""
+    row = _row()
+    assert row["finish_reason"] is None
+    assert row["truncated"] is None
+
+
+def test_build_row_records_thinking_tokens():
+    assert _row(thinking_tokens=243)["thinking_tokens"] == 243
+
+
+def test_build_row_total_tokens_prefers_reported_total():
+    """The API total includes thinking; input + output alone hides it."""
+    row = _row(input_tokens=392, output_tokens=9, thinking_tokens=243, total_tokens=644)
+    assert row["total_tokens"] == 644
+
+
+def test_build_row_total_tokens_falls_back_to_sum():
+    row = _row(input_tokens=100, output_tokens=50)
+    assert row["total_tokens"] == 150


### PR DESCRIPTION
Fixes #72.

## What was happening

Prod answers broke off mid-word while being logged `success = true`. Reproducing the refusal call against the live API found the cause:

`gemini-2.5-flash` runs **dynamic thinking by default**, thinking tokens **count against `max_output_tokens`**, and the refusal call capped that at **256**. Thinking consumed 217–248 of the budget, leaving 4–11 visible tokens and `finish_reason = MAX_TOKENS`.

```
gemini-2.5-flash, refusal prompt, max_output_tokens=256
  finish=MAX_TOKENS  visible=35  thinking=217  chars=197
  finish=MAX_TOKENS  visible=10  thinking=242  chars=55
  finish=MAX_TOKENS  visible=9   thinking=243  chars=36
```

Nothing caught it because nothing read `finish_reason` — an abnormal stop was indistinguishable from a clean one.

Two things in the data actively hid it, and both are fixed here:
- `thoughts_token_count` was never read, so the thinking spend was invisible.
- `build_row` recomputed `total_tokens` as `input + output`, discarding the API's real total. That made `total − input − output` always exactly `0`, which looked like proof that no thinking occurred. It was an artifact of the arithmetic, not a measurement.

## The fix

- **Disable thinking** on the router and refusal calls. Neither needs deliberation — the router emits one word, a refusal is one or two sentences.
- **Raise the refusal cap** to 1024 so the budget is not the binding limit.
- **Resolve the router model via `ROUTER_MODEL_NAME`**, defaulting to the pinned `gemini-2.5-flash`, so a candidate can be trialled in one environment without a code change.

## Observability, so it cannot hide again

- Capture `finish_reason` and log it; derive `truncated` from it. Null keeps meaning *unknown*, never *not truncated*.
- Capture `thoughts_token_count`, logged as `thinking_tokens`.
- Log the API's real `total_tokens` instead of recomputing it.
- Add `finish_reason`, `truncated`, `thinking_tokens` to `INTERACTIONS_SCHEMA` — they exist on the live table but were missing locally.

## On pinning a newer model

I measured the Gemini 3.x flash models for these calls and they are **worse**, so the router stays on 2.5:

| Model | thinking disabled? | Result at 256-token cap |
|---|---|---|
| `gemini-2.5-flash` | yes, `thinking_budget=0` | STOP, 0 thinking, complete answers |
| `gemini-3.7-flash` | no — ignores `thinking_budget` | MAX_TOKENS, ~241–248 thinking, truncated |
| `gemini-3.7-flash` | `thinking_level="low"` | MAX_TOKENS, 249 thinking, truncated |
| `gemini-3.7-flash` | `thinking_level="minimal"` | 400 INVALID_ARGUMENT — unsupported |

There is also no dated snapshot of `gemini-2.5-flash` on the API to pin to; the only text variants are the alias itself plus `-lite`. `ROUTER_MODEL_NAME` is the pinning mechanism instead.

## Verification

Both queries that truncated in prod, re-run end-to-end through the real agent against the live API:

| Query | Before | After |
|---|---|---|
| "Which company is the best performing stock for 2026" | 51 chars, mid-word | `STOP`, 213 chars, 0 thinking |
| "what is the top 3 preffered stocks to buy today" | 390 chars, mid-sentence | `STOP`, 340 chars, 0 thinking |

- 27 new tests, written test-first (each watched fail before implementing).
- Full suite: **220 passed / 35 failed**, against a clean `origin/main` baseline of **193 passed / 35 failed** — identical failures (all pre-existing GCP-credential errors in this environment), +27 passing.
- `ruff` and `black` clean.

## Follow-ups not in this PR

- The `output_tokens <= 15` detector proposed in #72 would have missed the 390-char / 80-token case. A "does the response end in terminal punctuation" check catches both shapes.
- Separate bug: the router refuses *"what was the best performing stock for 2025"* as unknowable future. `QUERY_ROUTER_PROMPT` sweeps superlative rankings into its forecast rule even in the past tense. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
