### PR TITLE
feat(cicd): gate prod deploy on eval suite passing against dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,183 @@
+name: Deploy
+
+# Auto-deploys to dev on every push to main, runs the live persona eval suite
+# against that dev deployment, and only then offers a prod deploy -- gated on
+# both the eval score (scripts/check_eval_gate.py) and a human approval
+# (the "prod" GitHub Environment's required reviewers).
+#
+# One-time setup required before this workflow can run -- see
+# docs/CI_CD_DEPLOY_PIPELINE.md for exact commands:
+#   - An IAM role for GitHub OIDC (repo variable AWS_DEPLOY_ROLE_ARN)
+#   - Secrets: COPILOT_API_MANIFEST, COPILOT_DEV_ENV_MANIFEST,
+#     COPILOT_PROD_ENV_MANIFEST, GEMINI_API_KEY
+#   - A "prod" GitHub Environment with required reviewers configured
+#   - A seeded baseline at evals/baselines/dev.json
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+env:
+  AWS_REGION: us-east-1
+  COPILOT_APP: jse-datasphere-chatbot
+  COPILOT_SVC: api
+  COPILOT_VERSION: v1.34.1
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-dev:
+    name: Deploy to dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    environment: dev
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      base_url: ${{ steps.url.outputs.base_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install AWS Copilot CLI
+        run: |
+          curl -sSL -o /usr/local/bin/copilot "https://github.com/aws/copilot-cli/releases/download/${{ env.COPILOT_VERSION }}/copilot-linux"
+          chmod +x /usr/local/bin/copilot
+          copilot --version
+
+      # api/manifest.yml and environments/dev/manifest.yml are gitignored
+      # (docs/SECRETS_MANAGEMENT.md) -- a fresh checkout never has them, so
+      # they're supplied here from repo secrets instead of the working tree.
+      - name: Write gitignored Copilot manifests
+        run: |
+          mkdir -p fastapi_app/copilot/api fastapi_app/copilot/environments/dev
+          cat > fastapi_app/copilot/api/manifest.yml <<'COPILOT_API_MANIFEST_EOF'
+          ${{ secrets.COPILOT_API_MANIFEST }}
+          COPILOT_API_MANIFEST_EOF
+          cat > fastapi_app/copilot/environments/dev/manifest.yml <<'COPILOT_DEV_ENV_MANIFEST_EOF'
+          ${{ secrets.COPILOT_DEV_ENV_MANIFEST }}
+          COPILOT_DEV_ENV_MANIFEST_EOF
+
+      - name: copilot svc deploy --env dev
+        working-directory: fastapi_app
+        run: copilot svc deploy --name "${{ env.COPILOT_SVC }}" --env dev
+
+      - name: Resolve dev base URL
+        id: url
+        run: |
+          BASE_URL="${{ vars.DEV_BASE_URL || 'http://jse-da-Publi-3w4oxbvTf5j0-374994583.us-east-1.elb.amazonaws.com' }}"
+          echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for dev /health
+        run: |
+          for i in $(seq 1 20); do
+            if curl -fsS "${{ steps.url.outputs.base_url }}/health"; then exit 0; fi
+            sleep 15
+          done
+          echo "::error::dev /health did not turn healthy in time"
+          exit 1
+
+  eval-gate:
+    name: Eval suite regression gate (dev)
+    runs-on: ubuntu-latest
+    needs: deploy-dev
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install eval suite
+        run: |
+          cd evals
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run eval suite against dev
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          python scripts/run_eval.py \
+            --base-url "${{ needs.deploy-dev.outputs.base_url }}" \
+            --replicates 1 \
+            --concurrency 3 \
+            --max-cost-usd 5 \
+            --run-id "ci-${{ github.run_id }}"
+
+      # Reads by_category.positive (not `overall`, which is dragged down by
+      # by-design-passing refusal personas) and fails the job on regression
+      # vs evals/baselines/dev.json. See scripts/check_eval_gate.py.
+      - name: Check regression gate
+        run: python scripts/check_eval_gate.py "evals/runs/ci-${{ github.run_id }}"
+
+      - name: Upload eval run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-run-ci-${{ github.run_id }}
+          path: evals/runs/ci-${{ github.run_id }}
+          retention-days: 30
+
+  deploy-prod:
+    name: Deploy to prod
+    runs-on: ubuntu-latest
+    needs: eval-gate
+    timeout-minutes: 25
+    # Configure required reviewers on this Environment in repo settings --
+    # that's the manual-approval half of the gate. The job won't even start
+    # until eval-gate succeeds; it then waits for approval.
+    environment: prod
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install AWS Copilot CLI
+        run: |
+          curl -sSL -o /usr/local/bin/copilot "https://github.com/aws/copilot-cli/releases/download/${{ env.COPILOT_VERSION }}/copilot-linux"
+          chmod +x /usr/local/bin/copilot
+
+      - name: Write gitignored Copilot manifests
+        run: |
+          mkdir -p fastapi_app/copilot/api fastapi_app/copilot/environments/prod
+          cat > fastapi_app/copilot/api/manifest.yml <<'COPILOT_API_MANIFEST_EOF'
+          ${{ secrets.COPILOT_API_MANIFEST }}
+          COPILOT_API_MANIFEST_EOF
+          cat > fastapi_app/copilot/environments/prod/manifest.yml <<'COPILOT_PROD_ENV_MANIFEST_EOF'
+          ${{ secrets.COPILOT_PROD_ENV_MANIFEST }}
+          COPILOT_PROD_ENV_MANIFEST_EOF
+
+      - name: copilot svc deploy --env prod
+        working-directory: fastapi_app
+        run: copilot svc deploy --name "${{ env.COPILOT_SVC }}" --env prod
+
+      - name: Verify prod /health
+        run: |
+          BASE_URL="${{ vars.PROD_BASE_URL || 'http://jse-da-Publi-2tSlV7zf7Ysl-685234288.us-east-1.elb.amazonaws.com' }}"
+          for i in $(seq 1 20); do
+            if curl -fsS "$BASE_URL/health"; then exit 0; fi
+            sleep 15
+          done
+          echo "::error::prod /health did not turn healthy in time"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.json
 !metadata-example.json
 !companies.json
+!evals/baselines/*.json
 
 # Python
 __pycache__/

--- a/docs/CI_CD_DEPLOY_PIPELINE.md
+++ b/docs/CI_CD_DEPLOY_PIPELINE.md
@@ -127,9 +127,9 @@ gh variable set AWS_DEPLOY_ROLE_ARN --body "arn:aws:iam::925030480327:role/jse-d
 
 **Keeping the manifest secrets in sync:** these are a snapshot, not a live reference to your working tree. If you hand-edit `manifest.yml` locally (e.g. bumping `cpu`/`memory`), re-run the matching `gh secret set` command or the pipeline will deploy the old config. This is the same manifest-drift risk noted in [[project_aws_account_migration]] — the pipeline doesn't fix it, it just relocates "the one place manifests live" from a laptop's working tree to GitHub secrets.
 
-## 4. Seed the regression baseline
+## 4. Seed the regression baseline (done — 2026-08-26)
 
-`scripts/check_eval_gate.py` gates on regression vs. a baseline, not an absolute score — there's no principled absolute cutoff for this judge's 1–5 scale yet. Seed it once from a run you've reviewed and are happy with:
+`scripts/check_eval_gate.py` gates on regression vs. a baseline, not an absolute score — there's no principled absolute cutoff for this judge's 1–5 scale yet.
 
 ```bash
 python scripts/run_eval.py --base-url http://jse-da-Publi-3w4oxbvTf5j0-374994583.us-east-1.elb.amazonaws.com --replicates 1 --run-id baseline_seed
@@ -138,12 +138,15 @@ git add evals/baselines/dev.json
 git commit -m "chore(evals): seed dev regression baseline"
 ```
 
-Without `evals/baselines/dev.json` committed, every `eval-gate` run fails immediately with a clear "no baseline" error rather than silently passing.
+`evals/baselines/dev.json` is now committed. Without it, every `eval-gate` run fails immediately with a clear "no baseline" error rather than silently passing.
 
-**Deliberately re-baselining** (e.g. after a reviewed prompt change that legitimately shifts scores): re-run `--update-baseline` by hand and commit the new file with a commit message explaining why. Never wire `--update-baseline` into the pipeline itself — that would let a slow score decline become the new normal one green build at a time.
+**Important — the seed run had 10/26 `fail` verdicts (positive category), not 0.** Most trace to known data-coverage gaps, not app bugs: e.g. `investor_compare_ncb_vs_jmmb` and `senior_analyst_ncb_financials` ask for NCBFG years the DB doesn't have (see [[reference_dev_table_net_profit_years]]), and `technical_trader_market_data` asks for trading-volume/market-cap fields that were never in this data model. Because of this, `check_eval_gate.py`'s fail-verdict check is **relative to the baseline's own fail count** (`--max-fail-increase`, default tolerance 2), not an absolute cap of 0 — an absolute-zero cap would have failed every future run, including a perfect no-op deploy, since today's floor already has 10.
+
+Re-baseline deliberately after any change that legitimately shifts scores (a reviewed prompt fix, new data coverage) — re-run `--update-baseline` by hand and commit the new file with a commit message explaining why. Never wire `--update-baseline` into the pipeline itself — that would let a slow score decline become the new normal one green build at a time.
 
 ## Notes / things worth revisiting later
 
 - The IAM policy in step 1 is a starting point; tighten or extend it as real deploys reveal what's actually needed.
-- `check_eval_gate.py` doesn't check the `record_count: 10557` red flag from [[reference_eval_suite]] (financial tool dumping the whole table) — a real regression could hide behind passing scores if the judge doesn't penalize it. Worth adding if it recurs.
-- `eval-gate` costs ~$0.35 and ~10 min per run (22 personas, `--replicates 1`) — cheap enough to run on every push to `main`, per [[reference_eval_suite]].
+- **New finding from the baseline seed run, unrelated to this pipeline:** several judge-flagged `hallucination` moments where the bot treats 2025/2026 events as futuristic and fabricates details (a nonexistent "2025 Annual Report," a fabricated hurricane) — e.g. `analyst_finds_latest_annual_report`, `diaspora_investor_jse_access`, `esg_conscious_investor` in `evals/runs/baseline_seed/`. Looks like a temporal-grounding bug (the model not being told "today" is actually in the past relative to these dates), separate from anything this pipeline fixes. Worth its own investigation.
+- `check_eval_gate.py` doesn't check the `record_count: 10557` red flag from [[reference_eval_suite]] (financial tool dumping the whole table) — a real regression could hide behind passing scores if the judge doesn't penalize it. Worth adding if it recurs. (Not seen in the baseline seed run.)
+- `eval-gate` costs ~$0.35 and ~10 min per run (26 personas, `--replicates 1`) — cheap enough to run on every push to `main`, per [[reference_eval_suite]].

--- a/docs/CI_CD_DEPLOY_PIPELINE.md
+++ b/docs/CI_CD_DEPLOY_PIPELINE.md
@@ -1,0 +1,149 @@
+# CI/CD Deploy Pipeline Setup
+
+Covers one-time setup for [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml): push to `main` → `copilot svc deploy --env dev` → run the eval suite against dev → (score pass + human approval) → `copilot svc deploy --env prod`.
+
+None of the steps below can be done by an agent — they touch IAM and repo/security settings. Run them yourself with the `ats-jse-elroy` SSO profile.
+
+## 1. IAM role for GitHub OIDC
+
+A GitHub OIDC provider already exists in this account (`arn:aws:iam::925030480327:oidc-provider/token.actions.githubusercontent.com`) — no need to create one. Create a role that trusts it, scoped to this repo.
+
+**Important:** the `deploy-dev` and `deploy-prod` jobs each declare `environment: dev` / `environment: prod`. GitHub sets the OIDC token's `sub` claim to `repo:<owner>/<repo>:environment:<name>` for jobs that declare an environment (not the branch ref) — the trust policy below matches on that.
+
+```bash
+export AWS_PROFILE=ats-jse-elroy AWS_DEFAULT_REGION=us-east-1
+
+cat > /tmp/gha-trust-policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Federated": "arn:aws:iam::925030480327:oidc-provider/token.actions.githubusercontent.com" },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": { "token.actions.githubusercontent.com:aud": "sts.amazonaws.com" },
+      "StringLike": {
+        "token.actions.githubusercontent.com:sub": [
+          "repo:Aeontsolutions/jse-datasphere-chatbot:environment:dev",
+          "repo:Aeontsolutions/jse-datasphere-chatbot:environment:prod"
+        ]
+      }
+    }
+  }]
+}
+EOF
+
+aws iam create-role \
+  --role-name jse-datasphere-chatbot-gha-deploy \
+  --assume-role-policy-document file:///tmp/gha-trust-policy.json \
+  --description "GitHub Actions OIDC role for jse-datasphere-chatbot deploy.yml"
+```
+
+Attach a permissions policy. `copilot svc deploy` drives a CloudFormation change set that touches ECS, ECR, SSM, logs, ELB target groups, and IAM role passing — this is a **scoped starting point**, not guaranteed complete. Expect an `AccessDenied` on the first real run; add the missing action (CloudTrail will name it) rather than widening broadly.
+
+```bash
+cat > /tmp/gha-deploy-policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Sid": "AccountWideReadOnly", "Effect": "Allow", "Action": [
+        "sts:GetCallerIdentity", "ecr:GetAuthorizationToken", "ecs:DescribeClusters",
+        "cloudformation:DescribeStacks", "cloudformation:DescribeStackEvents",
+        "cloudformation:ListStacks", "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeTags", "iam:ListRoles"
+      ], "Resource": "*" },
+    { "Sid": "CloudFormationStack", "Effect": "Allow", "Action": [
+        "cloudformation:CreateChangeSet", "cloudformation:DescribeChangeSet",
+        "cloudformation:ExecuteChangeSet", "cloudformation:DeleteChangeSet",
+        "cloudformation:GetTemplate", "cloudformation:GetTemplateSummary",
+        "cloudformation:ListStackResources", "cloudformation:UpdateStack"
+      ], "Resource": "arn:aws:cloudformation:us-east-1:925030480327:stack/jse-datasphere-chatbot-*/*" },
+    { "Sid": "ECR", "Effect": "Allow", "Action": [
+        "ecr:BatchCheckLayerAvailability", "ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage",
+        "ecr:PutImage", "ecr:InitiateLayerUpload", "ecr:UploadLayerPart", "ecr:CompleteLayerUpload",
+        "ecr:DescribeRepositories", "ecr:DescribeImages"
+      ], "Resource": "arn:aws:ecr:us-east-1:925030480327:repository/jse-datasphere-chatbot/*" },
+    { "Sid": "ECS", "Effect": "Allow", "Action": [
+        "ecs:DescribeServices", "ecs:UpdateService", "ecs:RegisterTaskDefinition",
+        "ecs:DescribeTaskDefinition", "ecs:DeregisterTaskDefinition", "ecs:ListTasks",
+        "ecs:DescribeTasks", "ecs:TagResource"
+      ], "Resource": "*", "Condition": { "StringLike": { "ecs:cluster": "arn:aws:ecs:us-east-1:925030480327:cluster/jse-datasphere-chatbot-*" } } },
+    { "Sid": "SSMSecrets", "Effect": "Allow", "Action": ["ssm:GetParameter", "ssm:GetParameters"],
+      "Resource": "arn:aws:ssm:us-east-1:925030480327:parameter/copilot/jse-datasphere-chatbot/*" },
+    { "Sid": "Logs", "Effect": "Allow", "Action": [
+        "logs:CreateLogGroup", "logs:PutRetentionPolicy", "logs:DescribeLogGroups", "logs:TagResource"
+      ], "Resource": "arn:aws:logs:us-east-1:925030480327:log-group:/copilot/jse-datasphere-chatbot-*" },
+    { "Sid": "PassRole", "Effect": "Allow", "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::925030480327:role/jse-datasphere-chatbot-*" }
+  ]
+}
+EOF
+
+aws iam put-role-policy \
+  --role-name jse-datasphere-chatbot-gha-deploy \
+  --policy-name deploy-scoped \
+  --policy-document file:///tmp/gha-deploy-policy.json
+
+aws iam get-role --role-name jse-datasphere-chatbot-gha-deploy --query 'Role.Arn' --output text
+rm /tmp/gha-trust-policy.json /tmp/gha-deploy-policy.json
+```
+
+Save the printed ARN — it's `AWS_DEPLOY_ROLE_ARN` in step 3.
+
+## 2. GitHub Environments (approval gate + per-env config)
+
+Repo → **Settings → Environments**:
+- **`dev`** — no protection rules needed (auto-deploys on push to `main`).
+- **`prod`** — add **Required reviewers** (yourself, at minimum). This is the human half of the gate: `deploy-prod` won't run until both `eval-gate` passes *and* a reviewer approves.
+
+## 3. Repo secrets and variables
+
+Repo → **Settings → Secrets and variables → Actions**.
+
+**Variables** (not secret — an OIDC role ARN and public ALB hostnames aren't credentials):
+| Name | Value |
+|---|---|
+| `AWS_DEPLOY_ROLE_ARN` | ARN from step 1 |
+| `DEV_BASE_URL` *(optional)* | `http://jse-da-Publi-3w4oxbvTf5j0-374994583.us-east-1.elb.amazonaws.com` — workflow already defaults to this; only add if the ALB is re-provisioned |
+| `PROD_BASE_URL` *(optional)* | `http://jse-da-Publi-2tSlV7zf7Ysl-685234288.us-east-1.elb.amazonaws.com` — same |
+
+**Secrets**:
+| Name | Value |
+|---|---|
+| `GEMINI_API_KEY` | A Gemini API key for the eval suite's persona actor + LLM judge (separate from the app's own runtime key in SSM) |
+| `COPILOT_API_MANIFEST` | Full contents of your working `fastapi_app/copilot/api/manifest.yml` |
+| `COPILOT_DEV_ENV_MANIFEST` | Full contents of `fastapi_app/copilot/environments/dev/manifest.yml` |
+| `COPILOT_PROD_ENV_MANIFEST` | Full contents of `fastapi_app/copilot/environments/prod/manifest.yml` |
+
+Set the manifest secrets from your local working copy (see [[deploy-to-aws-copilot]] if you need to fetch them from the main checkout first):
+
+```bash
+gh secret set COPILOT_API_MANIFEST < fastapi_app/copilot/api/manifest.yml
+gh secret set COPILOT_DEV_ENV_MANIFEST < fastapi_app/copilot/environments/dev/manifest.yml
+gh secret set COPILOT_PROD_ENV_MANIFEST < fastapi_app/copilot/environments/prod/manifest.yml
+gh secret set GEMINI_API_KEY   # paste the key at the prompt
+gh variable set AWS_DEPLOY_ROLE_ARN --body "arn:aws:iam::925030480327:role/jse-datasphere-chatbot-gha-deploy"
+```
+
+**Keeping the manifest secrets in sync:** these are a snapshot, not a live reference to your working tree. If you hand-edit `manifest.yml` locally (e.g. bumping `cpu`/`memory`), re-run the matching `gh secret set` command or the pipeline will deploy the old config. This is the same manifest-drift risk noted in [[project_aws_account_migration]] — the pipeline doesn't fix it, it just relocates "the one place manifests live" from a laptop's working tree to GitHub secrets.
+
+## 4. Seed the regression baseline
+
+`scripts/check_eval_gate.py` gates on regression vs. a baseline, not an absolute score — there's no principled absolute cutoff for this judge's 1–5 scale yet. Seed it once from a run you've reviewed and are happy with:
+
+```bash
+python scripts/run_eval.py --base-url http://jse-da-Publi-3w4oxbvTf5j0-374994583.us-east-1.elb.amazonaws.com --replicates 1 --run-id baseline_seed
+python scripts/check_eval_gate.py evals/runs/baseline_seed --update-baseline
+git add evals/baselines/dev.json
+git commit -m "chore(evals): seed dev regression baseline"
+```
+
+Without `evals/baselines/dev.json` committed, every `eval-gate` run fails immediately with a clear "no baseline" error rather than silently passing.
+
+**Deliberately re-baselining** (e.g. after a reviewed prompt change that legitimately shifts scores): re-run `--update-baseline` by hand and commit the new file with a commit message explaining why. Never wire `--update-baseline` into the pipeline itself — that would let a slow score decline become the new normal one green build at a time.
+
+## Notes / things worth revisiting later
+
+- The IAM policy in step 1 is a starting point; tighten or extend it as real deploys reveal what's actually needed.
+- `check_eval_gate.py` doesn't check the `record_count: 10557` red flag from [[reference_eval_suite]] (financial tool dumping the whole table) — a real regression could hide behind passing scores if the judge doesn't penalize it. Worth adding if it recurs.
+- `eval-gate` costs ~$0.35 and ~10 min per run (22 personas, `--replicates 1`) — cheap enough to run on every push to `main`, per [[reference_eval_suite]].

--- a/evals/baselines/dev.json
+++ b/evals/baselines/dev.json
@@ -1,0 +1,12 @@
+{
+  "source_run_id": "baseline_seed",
+  "category": "positive",
+  "means": {
+    "groundedness": 3.3333333333333335,
+    "factfulness": 3.380952380952381,
+    "goal_completion": 3.238095238095238,
+    "persona_handling": 3.4285714285714284,
+    "coherence": 3.2857142857142856
+  },
+  "fail_verdicts": 10
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,7 @@ Utility scripts for development, testing, and maintenance.
 
 - **run_server.py** - Runs the app locally (`uvicorn app.main:app`)
 - **run_eval.py** - Runs the persona-driven eval suite against `/chat/stream` and `/fast_chat_v2`
+- **check_eval_gate.py** - Gates a deploy on an eval run vs. a checked-in baseline (see `docs/CI_CD_DEPLOY_PIPELINE.md`)
 - **rebuild_metadata.py** - Rebuilds document metadata from S3 bucket
 - **run_metadata_rebuild.py** - Runner script for metadata rebuild
 - **find_unmapped_codes.py** - Identifies unmapped company codes

--- a/scripts/check_eval_gate.py
+++ b/scripts/check_eval_gate.py
@@ -47,6 +47,7 @@ def category_means(summary: dict, category: str) -> dict:
 
 def write_baseline(path: Path, summary: dict, category: str) -> None:
     means = category_means(summary, category)
+    fail_verdicts = summary["by_category"][category].get("verdict_counts", {}).get("fail", 0)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(
@@ -54,13 +55,14 @@ def write_baseline(path: Path, summary: dict, category: str) -> None:
                 "source_run_id": summary.get("run_id"),
                 "category": category,
                 "means": means,
+                "fail_verdicts": fail_verdicts,
             },
             indent=2,
         )
         + "\n",
         encoding="utf-8",
     )
-    print(f"Wrote baseline to {path} from run {summary.get('run_id')}: {means}")
+    print(f"Wrote baseline to {path} from run {summary.get('run_id')}: {means}, fail_verdicts={fail_verdicts}")
 
 
 def annotate(level: str, message: str) -> None:
@@ -81,10 +83,12 @@ def main() -> int:
         help="Max allowed drop (1-5 scale) per dimension vs baseline before failing (default: 0.4)",
     )
     parser.add_argument(
-        "--max-fail-verdicts",
+        "--max-fail-increase",
         type=int,
-        default=0,
-        help="Max allowed 'fail' verdicts in --category before failing (default: 0)",
+        default=2,
+        help="Max allowed increase in 'fail' verdicts vs baseline before failing (default: 2). Relative, "
+        "not absolute -- many 'fail' verdicts reflect known data-coverage gaps (personas asking for years "
+        "or fields the DB doesn't have), not app bugs, so an absolute cap of 0 would fail every run.",
     )
     parser.add_argument(
         "--max-judge-failed",
@@ -136,8 +140,14 @@ def main() -> int:
 
     cat_stats = summary["by_category"][args.category]
     fail_verdicts = cat_stats.get("verdict_counts", {}).get("fail", 0)
-    if fail_verdicts > args.max_fail_verdicts:
-        failures.append(f"{fail_verdicts} '{args.category}' conversations verdict=fail (max allowed {args.max_fail_verdicts})")
+    baseline_fail_verdicts = baseline.get("fail_verdicts", 0)
+    fail_increase = fail_verdicts - baseline_fail_verdicts
+    print(f"  fail_verdicts      baseline={baseline_fail_verdicts} current={fail_verdicts} increase={fail_increase:+d}")
+    if fail_increase > args.max_fail_increase:
+        failures.append(
+            f"fail_verdicts rose by {fail_increase} (baseline {baseline_fail_verdicts} -> {fail_verdicts}, "
+            f"max allowed increase {args.max_fail_increase})"
+        )
 
     judge_failed = summary.get("overall", {}).get("judge_failed_count", 0)
     if judge_failed > args.max_judge_failed:

--- a/scripts/check_eval_gate.py
+++ b/scripts/check_eval_gate.py
@@ -1,0 +1,161 @@
+"""Gate a deploy on eval-suite results: compares a run's summary.json against
+a checked-in baseline and fails (exit 1) on regression or hard-failure
+conditions. Used by .github/workflows/deploy.yml between the dev deploy and
+the prod deploy.
+
+Judge dimensions are scored 1-5 (see evals/judge.py). `overall` mixes in the
+negative/refusal personas, which score goal_completion=1.0 by design -- so
+this gate reads `by_category.positive` only, per evals/README and
+[[reference_eval_suite]].
+
+Usage:
+    # First time (or deliberately promoting a new baseline after a reviewed
+    # improvement): run the suite, then record it as the baseline to diff
+    # future runs against.
+    python scripts/check_eval_gate.py evals/runs/<run-id> --update-baseline
+
+    # Normal gate check (what CI runs):
+    python scripts/check_eval_gate.py evals/runs/<run-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BASELINE = REPO_ROOT / "evals" / "baselines" / "dev.json"
+DIMENSIONS = ("groundedness", "factfulness", "goal_completion", "persona_handling", "coherence")
+
+
+def load_summary(run_dir: Path) -> dict:
+    summary_path = run_dir / "summary.json"
+    if not summary_path.exists():
+        sys.exit(f"ERROR: {summary_path} not found -- did the eval run finish and write a report?")
+    return json.loads(summary_path.read_text(encoding="utf-8"))
+
+
+def category_means(summary: dict, category: str) -> dict:
+    cat = summary.get("by_category", {}).get(category)
+    if cat is None:
+        sys.exit(f"ERROR: summary has no by_category.{category} -- check personas were selected correctly")
+    return {dim: cat.get(f"mean_{dim}") for dim in DIMENSIONS}
+
+
+def write_baseline(path: Path, summary: dict, category: str) -> None:
+    means = category_means(summary, category)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "source_run_id": summary.get("run_id"),
+                "category": category,
+                "means": means,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote baseline to {path} from run {summary.get('run_id')}: {means}")
+
+
+def annotate(level: str, message: str) -> None:
+    print(message)
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print(f"::{level}::{message}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("run_dir", type=Path, help="evals/runs/<run-id> directory to check")
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--category", default="positive", help="by_category key to gate on (default: positive)")
+    parser.add_argument(
+        "--max-regression",
+        type=float,
+        default=0.4,
+        help="Max allowed drop (1-5 scale) per dimension vs baseline before failing (default: 0.4)",
+    )
+    parser.add_argument(
+        "--max-fail-verdicts",
+        type=int,
+        default=0,
+        help="Max allowed 'fail' verdicts in --category before failing (default: 0)",
+    )
+    parser.add_argument(
+        "--max-judge-failed",
+        type=int,
+        default=0,
+        help="Max allowed judge_failed_count (LLM-judge errors, not app failures) before failing (default: 0)",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Write this run's means as the new baseline instead of gating. Use deliberately, after "
+        "reviewing the run -- never wire this into an automatic pass/fail pipeline step, or a slow "
+        "score decline just becomes the new normal every time it happens to pass.",
+    )
+    args = parser.parse_args()
+
+    summary = load_summary(args.run_dir)
+
+    if args.update_baseline:
+        write_baseline(args.baseline, summary, args.category)
+        return 0
+
+    if not args.baseline.exists():
+        annotate(
+            "error",
+            f"No baseline at {args.baseline}. Seed one first: "
+            f"python scripts/check_eval_gate.py {args.run_dir} --update-baseline",
+        )
+        return 1
+
+    baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+    baseline_means = baseline["means"]
+    current = category_means(summary, args.category)
+
+    failures: list[str] = []
+    for dim in DIMENSIONS:
+        base_val = baseline_means.get(dim)
+        cur_val = current.get(dim)
+        if base_val is None:
+            continue
+        if cur_val is None:
+            failures.append(f"{dim}: no score in current run (baseline was {base_val})")
+            continue
+        drop = base_val - cur_val
+        flag = "REGRESSION" if drop > args.max_regression else "ok"
+        print(f"  {dim:18s} baseline={base_val:.2f} current={cur_val:.2f} drop={drop:+.2f}  [{flag}]")
+        if drop > args.max_regression:
+            failures.append(f"{dim} dropped {drop:.2f} (baseline {base_val:.2f} -> {cur_val:.2f}, max allowed {args.max_regression})")
+
+    cat_stats = summary["by_category"][args.category]
+    fail_verdicts = cat_stats.get("verdict_counts", {}).get("fail", 0)
+    if fail_verdicts > args.max_fail_verdicts:
+        failures.append(f"{fail_verdicts} '{args.category}' conversations verdict=fail (max allowed {args.max_fail_verdicts})")
+
+    judge_failed = summary.get("overall", {}).get("judge_failed_count", 0)
+    if judge_failed > args.max_judge_failed:
+        failures.append(f"{judge_failed} judge_failed_count (max allowed {args.max_judge_failed})")
+
+    incomplete = summary.get("overall", {}).get("incomplete_count", 0)
+    if incomplete:
+        annotate("warning", f"{incomplete} incomplete conversation(s) (transport errors) -- not gating on this, but worth a look.")
+
+    if failures:
+        annotate("error", f"EVAL GATE FAILED ({args.run_dir}, baseline {baseline.get('source_run_id')}):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print(f"EVAL GATE PASSED ({args.run_dir}, baseline {baseline.get('source_run_id')})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -25,11 +25,10 @@ ENV_PATH = REPO_ROOT / "fastapi_app" / ".env"
 # Keep in sync with AliasChoices in fastapi_app/app/config.py.
 API_KEY_ALIASES = ("GOOGLE_API_KEY", "GEMINI_API_KEY", "CHATBOT_API_KEY")
 
-if not ENV_PATH.exists():
-    print(f"ERROR: missing {ENV_PATH}", file=sys.stderr)
-    sys.exit(2)
-
-load_dotenv(ENV_PATH)
+if ENV_PATH.exists():
+    load_dotenv(ENV_PATH)
+# else: no local .env (e.g. CI, which injects the key via the environment
+# directly) -- fall through to the alias check below instead of erroring.
 
 if not os.environ.get("GOOGLE_API_KEY"):
     for alias in API_KEY_ALIASES:
@@ -39,7 +38,8 @@ if not os.environ.get("GOOGLE_API_KEY"):
     else:
         print(
             "ERROR: no Gemini API key found. Set one of "
-            f"{', '.join(API_KEY_ALIASES)} in {ENV_PATH}.",
+            f"{', '.join(API_KEY_ALIASES)} in {ENV_PATH}, or export it "
+            "directly in the environment (e.g. in CI).",
             file=sys.stderr,
         )
         sys.exit(2)


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml`: push to `main` -> `copilot svc deploy --env dev` (OIDC auth) -> run the full persona eval suite against dev -> `copilot svc deploy --env prod`, gated on both the eval score and a human approval (GitHub `prod` Environment required reviewers).
- Adds `scripts/check_eval_gate.py`, since `evals.cli` always exits 0 regardless of judge scores. Gates on `by_category.positive` (not the misleading `overall`, which is dragged down by by-design-passing refusal personas) against a committed baseline, relative rather than absolute — today's dev floor already has 10/26 fail verdicts from known data-coverage gaps (personas asking for years/fields the DB doesn't have), so an absolute zero-tolerance cap would fail every future run including a no-op deploy.
- Fixes `scripts/run_eval.py` to not hard-fail when `fastapi_app/.env` is absent (always true on a fresh CI checkout, since it's gitignored) -- falls through to reading the key from the environment directly.
- Seeds `evals/baselines/dev.json` from a real run against the live dev deployment.
- Adds `docs/CI_CD_DEPLOY_PIPELINE.md` covering the one-time AWS/GitHub setup (already completed: IAM OIDC role, `dev`/`prod` GitHub Environments, secrets/variables).

## Test plan
- [x] `scripts/check_eval_gate.py` unit-verified against synthetic pass/regression/fail-increase/no-baseline scenarios
- [x] `evals/` unit test suite passes (107 passed, 2 skipped) after the `run_eval.py` change
- [x] IAM role created and permissions policy verified attached (`AccountWideReadOnly`, `CloudFormationStack`, `ECR`, `ECS`, `SSMSecrets`, `Logs`, `PassRole`)
- [x] `dev` and `prod` GitHub Environments verified via API, `prod` has required reviewers
- [x] All required secrets/variables confirmed present (`gh secret list` / `gh variable list`)
- [x] Baseline seeded from a real run against dev and self-verified to pass the gate
- [ ] First real run of `.github/workflows/deploy.yml` once this merges to `main` -- IAM policy is a scoped starting point and may need an `AccessDenied` iteration or two

## Notes
- Also surfaced (not fixed here, spun off separately): the seed run flagged repeated hallucinations where the bot treats 2025/2026 events as futuristic and fabricates details -- looks like a temporal-grounding bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)