### PR TITLE
fix(evals): anchor judge prompt to the real run date

### DIFF
--- a/evals/judge.py
+++ b/evals/judge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
@@ -70,6 +71,15 @@ def load_rubric(path: Path) -> dict[str, Any]:
 
 
 _PROMPT_TEMPLATE = """You are an expert evaluator of a financial chatbot.
+
+# Current date
+Today's real-world date is {today}. Your own training data has an earlier
+cutoff -- do not use it to judge plausibility. A claim citing a report,
+filing, or market event dated on or before {today} is NOT "impossible",
+"hypothetical", or "future" just because it postdates what you were trained
+on. Only mark a claim as ungrounded or hallucinated when it conflicts with
+the transcript's own sources/metadata below, never because a date in it
+feels futuristic to you.
 
 # Persona under test
 - id: {persona_id}
@@ -169,11 +179,17 @@ class Judge:
         model: str,
         temperature: float,
         rubric_path: Path | None = None,
+        today: str | None = None,
     ) -> None:
         self._client = client
         self._model = model
         self._temperature = temperature
         self._rubric = load_rubric(rubric_path or DEFAULT_RUBRIC_PATH)
+        # Anchors the judge against its own training cutoff. Captured once per
+        # Judge instance (one per eval run) rather than per evaluate() call,
+        # since day-level granularity makes re-computing it per-conversation
+        # pointless.
+        self._today = today or datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     async def evaluate(
         self,
@@ -183,6 +199,7 @@ class Judge:
         totals = transcript.totals()
         transcript_block, truncated_turns = _format_transcript(transcript)
         prompt = _PROMPT_TEMPLATE.format(
+            today=self._today,
             persona_id=persona.id,
             persona_category=persona.category,
             character=persona.character.strip(),

--- a/evals/tests/test_judge.py
+++ b/evals/tests/test_judge.py
@@ -1,6 +1,7 @@
 """Tests for the Judge component."""
 
 import json
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -261,3 +262,38 @@ def test_load_rubric_is_public_and_returns_verdict_weights():
     assert "verdict_weights" in rubric
     assert "positive" in rubric["verdict_weights"]
     assert "negative" in rubric["verdict_weights"]
+
+
+# ---------------------------------------------------------------------------
+# Date anchoring -- the judge model's own training cutoff predates real
+# 2025/2026 events. Without an explicit anchor it can reason that a correct,
+# recent claim (e.g. a FY2025 annual report) is an "impossible future date"
+# and wrongly score it as ungrounded/hallucinated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_prompt_includes_explicit_run_date():
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = MagicMock(
+        return_value=_async_value(_mock_genai_response(_judge_response_json()))
+    )
+    judge = Judge(client=fake_client, model="gemini-2.5-pro", temperature=0.2, today="2026-08-27")
+    await judge.evaluate(persona=_persona(), transcript=_transcript())
+
+    sent_prompt = fake_client.aio.models.generate_content.call_args.kwargs["contents"][0]["parts"][0]["text"]
+    assert "2026-08-27" in sent_prompt
+
+
+@pytest.mark.asyncio
+async def test_judge_defaults_today_to_current_utc_date():
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = MagicMock(
+        return_value=_async_value(_mock_genai_response(_judge_response_json()))
+    )
+    judge = Judge(client=fake_client, model="gemini-2.5-pro", temperature=0.2)
+    await judge.evaluate(persona=_persona(), transcript=_transcript())
+
+    sent_prompt = fake_client.aio.models.generate_content.call_args.kwargs["contents"][0]["parts"][0]["text"]
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    assert today_str in sent_prompt


### PR DESCRIPTION
## Summary
- The LLM judge (`evals/judge.py`) never told the judge model what today's actual date is, so it could reason from its own training cutoff and score accurate 2025/2026 facts (e.g. a real FY2025 annual report, current JSE index performance) as "impossible future dates" -- inflating groundedness/hallucination failures independent of the chatbot's real behavior.
- Added a "Current date" section to `_PROMPT_TEMPLATE` that explicitly anchors the judge and tells it not to treat dates on/before today as impossible or hypothetical.
- `Judge` now takes an optional `today: str | None` ctor param (defaults to real UTC today), captured once per `Judge` instance rather than threaded through every `evaluate()` call, since a `Judge` is constructed once per eval run and day-level granularity doesn't need per-conversation recomputation.

Note: an earlier writeup of this issue claimed the chatbot's own `agent_v2.py` already had this fix (`AgentV2._build_date_context_note`). That doesn't exist anywhere in this repo's history -- verified via repo-wide grep and `git log -S` across all branches. The underlying diagnosis is still correct and worth fixing on its own merits; there was just no existing precedent to mirror, so this was designed fresh.

## Test plan
- [x] Added `test_evaluate_prompt_includes_explicit_run_date` and `test_judge_defaults_today_to_current_utc_date` in `evals/tests/test_judge.py` (written first, confirmed failing before the fix)
- [x] `python -m pytest evals/tests/ --ignore=evals/tests/test_judge_calibration.py` -- 109 passed, no regressions
- [ ] Live calibration re-run (`evals/tests/test_judge_calibration.py`, or a full `scripts/run_eval.py` before/after comparison) not run here -- no `GOOGLE_API_KEY`/`GEMINI_API_KEY` configured in this worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)